### PR TITLE
Labjack driver docu fixes

### DIFF
--- a/src/Logger-Labjack_T-Series-ADC/html_docu.py
+++ b/src/Logger-Labjack_T-Series-ADC/html_docu.py
@@ -15,19 +15,19 @@ errors_url = (
 )
 
 # HTML hyper links
-ljm_hyperlink = f'<a href="{url}">LJM software</a>'
+ljm_hyperlink = f'<a href="{ljm_url}">LJM software</a>'
 pin_names_hyperlink = f'<a href="{pins_dio_url}">docu table 13</a>'
 hardware_hyperlink = f'<a href="{hardware_url}">pin functions</a'
 error_hyperlink = f'<a href="{errors_url}">error codes</a>'
 
 # HTML Driver text
 html_driver_descript = f"""
-    <h3>Driver to read labjack T4/T7's AIN and DIO pin inputs</h3>
+    <h3>Driver to read Labjack T4/T7's AIN and DIO pin inputs</h3>
     <p>The driver supports basic DIO read, basic AIN read and AIN extended functions (EF).<br>
     Instrument connections are based on serial numbers (use find ports).<br>
     EF settings will apply to all pins in the read list. To measure 2 different EFs from the same
-    labjack make a second logger instance in the sequencer with the same SN but different read names
-    and functions./p>
+    Labjack device make a second logger instance in the sequencer with the same SN but different read names
+    and functions.</p>
     <p>Requirements:</p>
     <ul>
     <li>Please install the {ljm_hyperlink} (before first run)</li>

--- a/src/Logger-Labjack_T-Series-ADC/main.py
+++ b/src/Logger-Labjack_T-Series-ADC/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
+Labjack_T_Series_BaseClass = imp.load_source(driver_name + ".BaseClass",
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source(driver_name + ".html_docu", main_path + os.sep + "html_docu.py")
 
 import numpy as np
 

--- a/src/Logger-Labjack_T-Series-ADC/main.py
+++ b/src/Logger-Labjack_T-Series-ADC/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_"+driver_name,
+Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu", main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
 
 import numpy as np
 

--- a/src/Logger-Labjack_T-Series-Counter/main.py
+++ b/src/Logger-Labjack_T-Series-Counter/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
+Labjack_T_Series_BaseClass = imp.load_source(driver_name + ".BaseClass",
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source(driver_name + ".html_docu", main_path + os.sep + "html_docu.py")
 
 
 class Device(Labjack_T_Series_BaseClass.LabjackBaseClass):

--- a/src/Logger-Labjack_T-Series-Counter/main.py
+++ b/src/Logger-Labjack_T-Series-Counter/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_"+driver_name,
+Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu", main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
 
 
 class Device(Labjack_T_Series_BaseClass.LabjackBaseClass):

--- a/src/Switch-Labjack_T-Series-TTL/main.py
+++ b/src/Switch-Labjack_T-Series-TTL/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
+Labjack_T_Series_BaseClass = imp.load_source(driver_name + ".BaseClass",
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source(driver_name + ".html_docu", main_path + os.sep + "html_docu.py")
 
 
 class Device(Labjack_T_Series_BaseClass.LabjackBaseClass):

--- a/src/Switch-Labjack_T-Series-TTL/main.py
+++ b/src/Switch-Labjack_T-Series-TTL/main.py
@@ -40,10 +40,10 @@ driver_name = os.path.basename(main_path)
 
 # We assign a module name that depends on the driver name to make sure each driver imports its own version
 # of the Base class as this reduces friction when SweepMe! labjack drivers use different versions of the base class.
-Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_"+driver_name,
+Labjack_T_Series_BaseClass = imp.load_source("Labjack_T_Series_BaseClass_" + driver_name,
                                              main_path + os.sep + "Labjack_T_Series_BaseClass.py")
 
-html_docu = imp.load_source("html_docu", main_path + os.sep + "html_docu.py")
+html_docu = imp.load_source("html_docu" + driver_name, main_path + os.sep + "html_docu.py")
 
 
 class Device(Labjack_T_Series_BaseClass.LabjackBaseClass):


### PR DESCRIPTION
Fixing issue with using the correct html_docu file and correcting link in ADC driver docu.
The ADC driver had a broken link in the docu. Still, it was correctly shown because imp.load_source was importing information from other similar docu files of other driver versions. The import is now done with a more specific name.