### PR TITLE
Keithley 2400 fix

### DIFF
--- a/src/SMU-Keithley_2400/license.txt
+++ b/src/SMU-Keithley_2400/license.txt
@@ -5,7 +5,7 @@ find those in the corresponding folders or contact the maintainer.
 
 MIT License
 
-Copyright (c) 2018-2020 Axel Fischer (sweep-me.net)
+Copyright (c) 2023 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/SMU-Keithley_2400/main.py
+++ b/src/SMU-Keithley_2400/main.py
@@ -5,7 +5,7 @@
 #
 # MIT License
 # 
-# Copyright (c) 2018-2020 Axel Fischer (sweep-me.net)
+# Copyright (c) 2023 SweepMe! GmbH (sweep-me.net)
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@ from EmptyDeviceClass import EmptyDevice
 import numpy as np
 import time
 
+
 class Device(EmptyDevice):
 
     def __init__(self):
@@ -43,42 +44,53 @@ class Device(EmptyDevice):
         
         self.shortname = "Keithley2400"
         
-        self.variables =["Voltage", "Current"]
-        self.units =    ["V", "A"]
-        self.plottype = [True, True] # True to plot data
-        self.savetype = [True, True] # True to save data
+        self.variables = ["Voltage", "Current"]
+        self.units = ["V", "A"]
+        self.plottype = [True, True]  # True to plot data
+        self.savetype = [True, True]  # True to save data
 
         self.port_manager = True
         self.port_types = ["COM", "GPIB"]
         
-        self.port_properties = { "timeout": 10,
-                                 "EOL": "\r", 
-                                 "baudrate": 9600,
-                                 # this are the default values with which a new device is shipped
-                                 }
+        self.port_properties = {
+            "timeout": 10,
+            "EOL": "\r",
+            "baudrate": 9600,
+        }
                                  
         self.commands = {
-                        "Voltage [V]" : "VOLT",
-                        "Current [A]" : "CURR",
-                        }
+            "Voltage in V": "VOLT",
+            "Current in A": "CURR",
+            "Voltage [V]": "VOLT",  # deprecated, remains for compatibility reasons
+            "Current [A]": "CURR",  # deprecated, remains for compatibility reasons
+        }
                         
         self.outpon = False 
                                  
     def set_GUIparameter(self):
         
-        GUIparameter = {
-                        "SweepMode" : ["Voltage [V]", "Current [A]"],
-                        "RouteOut": ["Front", "Rear"],
-                        "Speed": ["Fast", "Medium", "Slow"],
-                        "Range": ["Auto", "10 nA", "100 nA", "1 µA", "10 µA", "100 µA", "1 mA", "10 mA", "100 mA", "1 A"],   
-                        "Compliance": 100e-6,
-                        "Average": 1,
-                        "4wire": False,
-                        }
+        gui_parameter = {
+            "SweepMode": ["Voltage in V", "Current in A"],
+            "RouteOut": ["Front", "Rear"],
+            "Speed": ["Fast", "Medium", "Slow"],
+            "Range": ["Auto",
+                      "10 nA",
+                      "100 nA",
+                      "1 µA",
+                      "10 µA",
+                      "100 µA",
+                      "1 mA",
+                      "10 mA",
+                      "100 mA",
+                      "1 A", ],
+            "Compliance": 100e-6,
+            "Average": 1,
+            "4wire": False,
+        }
                         
-        return GUIparameter
+        return gui_parameter
                                  
-    def get_GUIparameter(self, parameter = {}):
+    def get_GUIparameter(self, parameter={}):
         self.four_wire = parameter['4wire']
         self.route_out = parameter['RouteOut']
         self.source = parameter['SweepMode']
@@ -87,37 +99,47 @@ class Device(EmptyDevice):
         self.speed = parameter['Speed']
         self.average_gui = int(parameter['Average'])
         self.port_string = parameter["Port"]
-        
-        
+
         self.average = self.average_gui
         if self.average_gui < 1:
             self.average = 1
         if self.average_gui > 100:
             self.average = 100
-                
-       
+
     def initialize(self):
-      
+
+        identifier = self.get_identification()
+
+        vendor, model, sn_version, fw_version = identifier.split(",")
+        fw_version_year = int(fw_version.split()[3])
+
         # The Keithley 2400 supports two protocols: 488.1 and SCPI
-        # The SCPI protocol is better as it works more stable. If several devices are connected at the same time, the 488.1 protocol can lead to timeout errors
+        # The SCPI protocol is better as it works more stable. If several devices are connected at the same time,
+        # the 488.1 protocol can lead to timeout errors
         # Lets switch to SCPI protocol if 488.1 is currently selected
-        if not self.port_string.startswith("COM"): 
-            self.port.write("SYST:MEP:STAT?")
-            if self.port.read() == "0":
-                self.port.write("SYST:MEP:STAT 1")
-                time.sleep(0.1) # A short time is needed before the new protocol works and new commands can be received.
+        # This is only performed for firmware version later than 1998
+        if not self.port_string.startswith("COM") and fw_version_year > 1998:
+            try:
                 self.port.write("SYST:MEP:STAT?")
-                if self.port.read() == "1":
-                    print("Keithley 2400: SCPI protocol selected.")
-                else:
-                    print("Keithley 2400: Not able to select 488.1 protocol. Please change manually via Menu -> Communication -> GPIB -> GPIB Protocol")
+                if self.port.read() == "0":
+                    self.port.write("SYST:MEP:STAT 1")
+                    # A short time is needed before the new protocol works and new commands can be received.
+                    time.sleep(0.1)
+                    self.port.write("SYST:MEP:STAT?")
+                    if self.port.read() == "1":
+                        debug("Keithley 2400: GPIB communication protocol was changed to 'SCPI' automatically.")
+                    else:
+                        debug("Keithley 2400: Not able to select 488.1 protocol. "
+                              "Please change manually via Menu -> Communication -> GPIB -> GPIB Protocol")
+            except:
+                error("Unable to change GPIB communication protocol to 'SCPI' for identifier '%s'" % identifier)
         
         # once at the beginning of the measurement
-        self.port.write("*RST")
+        self.reset()
         # time.sleep(0.05) # maybe needed to prevent random "Undefined Header error -113"
-        self.port.write("*CLS") # reset all values
+        self.clear()
         
-        self.port.write("SYST:BEEP:STAT OFF")     # control-Beep off
+        self.port.write("SYST:BEEP:STAT OFF")  # control-beep off
 
         if self.average_gui > 100:
             self.message_Box("Maximum allowed average is 100 and average has been changed to 100")
@@ -125,51 +147,50 @@ class Device(EmptyDevice):
     def configure(self):
     
         if self.route_out == "Front":
-            self.port.write("ROUT:TERM FRON") # use front or rear terminal for power supply
+            self.port.write("ROUT:TERM FRON")  # use front or rear terminal for power supply
         if self.route_out == "Rear":
-            self.port.write("ROUT:TERM REAR") # use front or rear terminal for power supply
-        
-        
-        self.range = self.range.replace(" ", "").replace("p", "e-12").replace("n", "e-9").replace("µ", "e-6").replace("m", "e-3")
+            self.port.write("ROUT:TERM REAR")  # use front or rear terminal for power supply
+
+        self.range = (self.range.replace(" ", "").replace("p", "e-12").replace("n", "e-9").
+                      replace("µ", "e-6").replace("m", "e-3"))
     
-        if self.source == "Voltage [V]":
+        if self.source.startswith("Voltage"):
             self.port.write(":SOUR:FUNC VOLT")                  
             # sourcemode = Voltage
             self.port.write(":SOUR:VOLT:MODE FIX")
             # sourcemode fix
             self.port.write(":SENS:FUNC \"CURR\"")              
             # measurement mode
-            self.port.write(":SENS:CURR:PROT "+ self.protection)
+            self.port.write(":SENS:CURR:PROT " + self.protection)
             # Protection with Imax
             
-            if self.range == "Auto": # it means Auto was selected              
-                self.port.write(":SENS:CURR:RANG:AUTO ON") # Autorange for current measurement
+            if self.range == "Auto":  # it means Auto was selected
+                self.port.write(":SENS:CURR:RANG:AUTO ON")  # Autorange for current measurement
             else:
                 self.port.write(":SENS:CURR:RANG:AUTO OFF")
                 self.port.write(":SENS:CURR:RANG %s" % str(self.range.replace("A", "")))
 
-      
-        if self.source == "Current [A]":
+        elif self.source.startswith("Current"):
             self.port.write(":SOUR:FUNC CURR")                  
             # sourcemode = Voltage
             self.port.write(":SOUR:CURR:MODE FIX")
             # sourcemode fix
             self.port.write(":SENS:FUNC \"VOLT\"")              
             # measurement mode
-            self.port.write(":SENS:VOLT:PROT "+ self.protection)
+            self.port.write(":SENS:VOLT:PROT " + self.protection)
             # Protection with Imax
             
-            if self.range == "Auto": # it means Auto was selected
-                self.port.write(":SOUR:CURR:RANG:AUTO ON") # Autorange for voltage measurement
+            if self.range == "Auto":  # it means Auto was selected
+                self.port.write(":SOUR:CURR:RANG:AUTO ON")  # Autorange for voltage measurement
             else:
                 self.port.write(":SOUR:CURR:RANG:AUTO OFF")
                 self.port.write(":SOUR:CURR:RANG %s" % str(self.range.replace("A", "")))
                
         if self.speed == "Fast":
             self.nplc = 0.1
-        if self.speed == "Medium":
+        elif self.speed == "Medium":
             self.nplc = 1.0
-        if self.speed == "Slow":
+        elif self.speed == "Slow":
             self.nplc = 10.0
 
         self.port.write(":SENS:CURR:DC:NPLC " + str(self.nplc))
@@ -182,13 +203,16 @@ class Device(EmptyDevice):
             self.port.write("SYST:RSEN OFF")
         
         # averaging
-        self.port.write(":SENS:AVER:TCON REP")   # repeatedly take average
+        self.port.write(":SENS:AVER:TCON REP")  # repeatedly take average
         if self.average > 1:
             self.port.write(":SENS:AVER ON") 
-            self.port.write(":SENSe:AVER:COUN %i" % self.average)   # repeatedly take average
+            self.port.write(":SENSe:AVER:COUN %i" % self.average)  # repeatedly take average
         else:
             self.port.write(":SENS:AVER OFF")
-            self.port.write(":SENSe:AVER:COUN 1")  
+            self.port.write(":SENSe:AVER:COUN 1")
+
+        # let's ensure all parameters are set before we continue
+        self.wait_for_complete()
      
     def deinitialize(self):
         self.port.write("SYST:RSEN OFF")
@@ -198,14 +222,12 @@ class Device(EmptyDevice):
         self.port.write(":SENS:AVER OFF")
         self.port.write(":SENSe:AVER:COUN 1")  
         
-        self.port.write("SYST:BEEP:STAT ON")     # control-Beep on
+        self.port.write("SYST:BEEP:STAT ON")  # control-Beep on
         
         if self.port_string.startswith("COM"):
             self.port.write("SYST:LOC")  # RS-232/COM-port only
         else:
             self.port.write("GTL")
-            
-        
 
     def poweron(self):
         self.port.write("OUTP ON")
@@ -216,17 +238,11 @@ class Device(EmptyDevice):
         self.outpon = False    
               
     def apply(self):
-    
-        self.port.write(":SOUR:" + self.commands[self.source] + ":LEV %s" % self.value)        # set source
+        self.port.write(":SOUR:" + self.commands[self.source] + ":LEV %s" % self.value)  # set source
         
-        # needed to trigger a measurement which also triggers the final output of the level
-        if self.outpon:
-            self.measure()
-            self.call()
-         
-    def trigger(self):
-        pass
-                       
+    def reach(self):
+        self.wait_for_complete()
+
     def measure(self):    
         self.port.write("READ?")                                    
 
@@ -243,10 +259,29 @@ class Device(EmptyDevice):
             self.v = self.v[1:]
 
         return [float(self.v), float(self.i)]
-        
-    def finish(self):
-        pass
-        
-        
-    """
-    """
+
+    def get_identification(self):
+        """
+        Retrieves the identification string
+        """
+        self.port.write("*IDN?")
+        return self.port.read()
+
+    def reset(self):
+        """
+        Resets the instrument to default parameters
+        """
+        self.port.write("*RST")
+
+    def clear(self):
+        """
+        Clears the status register and error queue
+        """
+        self.port.write("*CLS")
+
+    def wait_for_complete(self):
+        """
+        Waits for the operation queue to be completed
+        """
+        self.port.write("*OPC")
+        return self.port.read()

--- a/src/SMU-Keithley_2400/main.py
+++ b/src/SMU-Keithley_2400/main.py
@@ -111,7 +111,11 @@ class Device(EmptyDevice):
         identifier = self.get_identification()
 
         vendor, model, sn_version, fw_version = identifier.split(",")
-        fw_version_year = int(fw_version.split()[3])
+
+        try:
+            fw_version_year = int(fw_version.split()[3])
+        except ValueError:
+            fw_version_year = -1  # unknown version
 
         # The Keithley 2400 supports two protocols: 488.1 and SCPI
         # The SCPI protocol is better as it works more stable. If several devices are connected at the same time,

--- a/src/SMU-Keithley_2400/main.py
+++ b/src/SMU-Keithley_2400/main.py
@@ -283,5 +283,5 @@ class Device(EmptyDevice):
         """
         Waits for the operation queue to be completed
         """
-        self.port.write("*OPC")
+        self.port.write("*OPC?")
         return self.port.read()


### PR DESCRIPTION
- *OPC? is used to make sure apply and configure are finished
- If firmware version is from 1998 or earlier the GPIB communication protocol is not changed automatically
- Revised sweep value names e.g. "Voltage in V" instead of "Voltage [V]", old definition is still supported
- License updated