### PR TITLE
Thorlabs PM100 -> no clear of the communication port

### DIFF
--- a/src/Logger-Thorlabs_PM100/main.py
+++ b/src/Logger-Thorlabs_PM100/main.py
@@ -85,6 +85,7 @@ class Device(EmptyDevice):
         self.port_types = ["USBTMC"]
         self.port_properties = {
             "timeout": 10,  # in seconds
+            "clear": False,  # there are problems if the port of the PM100 is cleared
         }
 
         self._target_wavelength = None  # correction wavelength from user interface


### PR DESCRIPTION
The port of the PM100 is not cleared because a user reported an issue with the instrument once a clear is called at the beginning. 