### PR TITLE
Agilent B29xx -> output protection removed in 'initialize' and moved …

### DIFF
--- a/src/SMU-Agilent_B29xx/main.py
+++ b/src/SMU-Agilent_B29xx/main.py
@@ -30,6 +30,9 @@
 # Type: SMU
 # Device: Agilent 29xx
 
+
+from __future__ import annotations
+
 from pysweepme.EmptyDeviceClass import EmptyDevice
 
 
@@ -197,7 +200,7 @@ class Device(EmptyDevice):
 
     # here functions wrapping communication commands start
 
-    def enable_output_protection(self, state: str|bool) -> None:
+    def enable_output_protection(self, state: str | bool) -> None:
         """Enables  over voltage / over current protection.
 
         If the SMU hits the compliance the output will be switched off. This features is a safety feature to prevent

--- a/src/SMU-Agilent_B29xx/main.py
+++ b/src/SMU-Agilent_B29xx/main.py
@@ -101,8 +101,6 @@ class Device(EmptyDevice):
 
         self.port.write(":SYST:LFR 50")  # LineFrequency = 50 Hz
 
-        self.port.write(":OUTP%s:PROT ON" % self.channel)  # enables  over voltage / over current protection
-
     def configure(self):
 
         if self.source.startswith("Voltage"):
@@ -196,3 +194,25 @@ class Device(EmptyDevice):
         current = float(values[1])
 
         return [voltage, current]
+
+    # here functions wrapping communication commands start
+
+    def enable_output_protection(self, state: str|bool) -> None:
+        """Enables  over voltage / over current protection.
+
+        If the SMU hits the compliance the output will be switched off. This features is a safety feature to prevent
+        further voltage or current being applied to the device under test.
+
+        The output protection does not change whether the compliance is active.
+
+        The default after a reset (*RST) of the device is OFF.
+        """
+        if state is True or state == "ON":
+            state = "ON"
+        elif state is False or state == "OFF":
+            state = "OFF"
+        else:
+            msg = "State '%s' unknown and cannot be handled." % str(state)
+            raise Exception(msg)
+
+        self.port.write(f":OUTP{self.channel}:PROT {state}")


### PR DESCRIPTION
…to an own function for later use.

It has been removed because the compliance is still active but the output protection switched the SMU off once the calibration is hit.

Thus, the new behavior is now similar to all other SMU drivers where the SMU regualtes the voltage when the compliance is reached but one can still contrinue to measure when the compliance is left again.

To keep the function, it has been wrapped as an own command function at the end of the driver.