### PR TITLE
Fixed depricated time.clock call

### DIFF
--- a/src/LockIn-Stanford_SR86x/main.py
+++ b/src/LockIn-Stanford_SR86x/main.py
@@ -373,11 +373,13 @@ class Device(EmptyDevice):
         answer = self.port.read()
         
         # This time reference to wait several time constants.
-        self.time_ref = time.clock()
+        self.time_ref = time.perf_counter()
 
     def trigger_ready(self):
         # make sure that at least several time constants have passed since 'Auto sensitivity' was called
-        delta_time = (self.waittimeconstants * self.unit_to_float(self.timeconstant)) - (time.clock()-self.time_ref)
+        delta_time = (
+            self.waittimeconstants * self.unit_to_float(self.timeconstant)
+        ) - (time.perf_counter() - self.time_ref)
         if delta_time > 0.0:
             # wait several time constants to allow for a renewal of the result
             time.sleep(delta_time)


### PR DESCRIPTION
User contribution
Replaced the time.clock() call with time.perf_counter() in LockIn-Stanford_SR86x
time.clock() was deprecated in Python 3.3. and removed in Python 3.8

There are no further occurrences of time.clock() in the repo, so we can merge it to main now.