### PR TITLE
K2000 Close port on disconnect

### DIFF
--- a/src/Logger-Keithley_2000/main.py
+++ b/src/Logger-Keithley_2000/main.py
@@ -241,7 +241,10 @@ class Device(EmptyDevice):
         answer = self.port.read()  # here we read the response from the "READ?" request in 'measure'
         #print("Response to READ? command:", answer)
 
-        return [float(answer)] 
+        return [float(answer)]
+
+    def disconnect(self):
+        self.port.close() 
         
         
     """


### PR DESCRIPTION
Added closing of the port on the disconnect function.

The port was never closed when we used this device, causing repeated script executions to fail. 
It seems the port was never closed at the end of using it in one script. 
Is this the only way or is there some better way to handle closing of ports at the end of a script execution with these drivers?

