### PR TITLE
Rotrics DexArm -> corrected use of port property key 'timeout'

### DIFF
--- a/src/Robot-Rotrics_DexArm/main.py
+++ b/src/Robot-Rotrics_DexArm/main.py
@@ -109,7 +109,7 @@ class Device(EmptyDevice):
 
         self.port_properties = {
             "baudrate": 115200,
-            "timeout:": 5,
+            "timeout": 5,
         }
 
         self.module_type_dict = {


### PR DESCRIPTION
Finally figured out why SweepMe! was not happy with the timeout keyword in self.port_properties ...