### PR TITLE
adding measurement in DC mode also into 'measure' section

### DIFF
--- a/src/SMU-Agilent_B29xx/main.py
+++ b/src/SMU-Agilent_B29xx/main.py
@@ -437,6 +437,9 @@ class Device(EmptyDevice):
         if self.pulse:
             # releasing the pulse trigger, just at the moment when the measurement should be performed
             self.port.write(":INIT (@%s)" % self.channel)
+        else:
+            # taking a measurement during constant DC output
+            self.port.write(":MEAS? (@%s)" % self.channel)
 
     def call(self):
         
@@ -460,10 +463,7 @@ class Device(EmptyDevice):
                     opcounter += 1
                     time.sleep(0.5)
 
-            self.port.write(
-                ":FETC:ARR? (@%s)" % self.channel)  # get measured values taken during pulse release out of the memory
-        else:
-            self.port.write(":MEAS? (@%s)" % self.channel)  # taking a measurement during constant DC output
+            self.port.write(":FETC:ARR? (@%s)" % self.channel)  # get measured values taken during pulse release out of the memory
 
         answer = self.port.read()
 


### PR DESCRIPTION
After deleting the exidentially created 'patch-1' branch in my repo I would like to continue the discussion about the move of the pulse emission into the 'measure' section of the driver.

IMHO, the move of the pulse emission is justified as the measurement is taken simultaniously and therefore belongs foremost to the 'measure' section instead of the 'apply' section. It is therefore a good idea.

However, we should definitly keep the structure conclusive by moving the measurement of the supplied current and voltage in DC mode into the 'measure' section of the driver as well while leaving the application of the output in the 'apply' section as measurement and application are seperated in time for DC, contrary to the Pulse mode.

This commit takes care of the move of the measurement in DC mode.