### PR TITLE
move measure of DC values to 'measure' routine just like the application and measure of pulses

### DIFF
--- a/src/SMU-Agilent_B29xx/main.py
+++ b/src/SMU-Agilent_B29xx/main.py
@@ -463,7 +463,8 @@ class Device(EmptyDevice):
                     opcounter += 1
                     time.sleep(0.5)
 
-            self.port.write(":FETC:ARR? (@%s)" % self.channel)  # get measured values taken during pulse release out of the memory
+            # get measured values taken during pulse release out of the memory
+            self.port.write(":FETC:ARR? (@%s)" % self.channel)
 
         answer = self.port.read()
 

--- a/src/SMU-Agilent_B29xx/main.py
+++ b/src/SMU-Agilent_B29xx/main.py
@@ -437,6 +437,9 @@ class Device(EmptyDevice):
         if self.pulse:
             # releasing the pulse trigger, just at the moment when the measurement should be performed
             self.port.write(":INIT (@%s)" % self.channel)
+        else:
+            # taking a measurement during constant DC output
+            self.port.write(":MEAS? (@%s)" % self.channel)
 
     def call(self):
         
@@ -460,10 +463,7 @@ class Device(EmptyDevice):
                     opcounter += 1
                     time.sleep(0.5)
 
-            self.port.write(
-                ":FETC:ARR? (@%s)" % self.channel)  # get measured values taken during pulse release out of the memory
-        else:
-            self.port.write(":MEAS? (@%s)" % self.channel)  # taking a measurement during constant DC output
+            self.port.write(":FETC:ARR? (@%s)" % self.channel)  # get measured values taken during pulse release out of the memory
 
         answer = self.port.read()
 


### PR DESCRIPTION
After the move of the application and simultaneous measure of pulses to the 'measure' routine, we should definitly keep the structure conclusive by moving the measurement of supplied current and voltage in DC mode into the 'measure' section of the driver as well while leaving the application of the output in the 'apply' section as measurement and application are seperated in time for DC, contrary to the Pulse mode.