### PR TITLE
enhance NGU compatibility

### DIFF
--- a/src/SMU-Rohde&Schwarz_NGx/license.txt
+++ b/src/SMU-Rohde&Schwarz_NGx/license.txt
@@ -5,7 +5,7 @@ find those in the corresponding folders or contact the maintainer.
 
 MIT License
 
-Copyright (c) 2022-2023 SweepMe! GmbH (sweep-me.net)
+Copyright (c) 2022-2024 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -118,8 +118,7 @@ class Device(EmptyDevice):
         self.set_current_range(self.current_range)
 
         # Channel
-        if self.model != "NGU":
-            self.set_channel(self.channel)
+        self.set_channel(self.channel)
 
         # Source
         if self.source.startswith("Voltage"):
@@ -279,7 +278,8 @@ class Device(EmptyDevice):
         Returns:
             None
         """
-        self.port.write("INST:OUT%i" % int(channel))
+        if self.model != "NGU":
+            self.port.write("INST:OUT%i" % int(channel))
 
     def set_voltage(self, voltage):
         """

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -105,8 +105,8 @@ class Device(EmptyDevice):
                 self.port.port.read_termination = '\n'
 
     def initialize(self):
-        # identifier = self.get_identification()
-        # print("Identifier:", identifier)  # can be used to check the instrument
+        identifier = self.get_identification()
+        #print("Identifier:", identifier)  # can be used to check the instrument
         self.reset_instrument()
 
     def configure(self):
@@ -122,7 +122,10 @@ class Device(EmptyDevice):
             self.set_current(0.0)
             self.set_voltage(self.protection)
         if self.speed == "Fast":
-            self.set_nplc(0.1)
+            if self.model == "NGU":
+                self.set_nplc(0)
+            else:
+                self.set_nplc(0.1)
         if self.speed == "Medium":
             self.set_nplc(1)
         if self.speed == "Slow":
@@ -182,6 +185,9 @@ class Device(EmptyDevice):
         """
         self.port.write("*IDN?")
         answer = self.port.read()
+        if answer.find("NGU") > 0:
+            self.model = "NGU"
+        
         return answer
 
     def get_options(self):
@@ -192,6 +198,7 @@ class Device(EmptyDevice):
         """
         self.port.write("*OPT?")
         answer = self.port.read()
+        
         return answer
 
     def reset_instrument(self):
@@ -201,6 +208,7 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("*RST")
+        
 
     def set_voltage_limit(self, protection):
         """
@@ -212,6 +220,7 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("ALIM 1")  # To make sure that the safety limits are on beforehand.
+        
         self.port.write("VOLT:ALIM %1.3f" % float(protection))
 
     def get_voltage_limit(self):
@@ -222,6 +231,7 @@ class Device(EmptyDevice):
         """
         self.port.write("VOLT:ALIM?")
         answer = self.port.read()
+        
         return answer
 
     def set_current_limit(self, protection):
@@ -234,8 +244,9 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("ALIM 1")
+        
         self.port.write("CURR:ALIM %1.4f" % float(protection))
-
+        
     def get_current_limit(self):
         """
         This function gets the current limit of the instrument.
@@ -244,6 +255,7 @@ class Device(EmptyDevice):
         """
         self.port.write("CURR:ALIM?")
         answer = self.port.read()
+        
         return answer
 
     def set_channel(self, channel):
@@ -256,7 +268,8 @@ class Device(EmptyDevice):
         Returns:
             None
         """
-        self.port.write("INST:OUT%i" % int(channel))
+        if self.model != "NGU":
+            self.port.write("INST:OUT%i" % int(channel))
 
     def set_voltage(self, voltage):
         """
@@ -268,7 +281,7 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("VOLT %1.3f" % float(voltage))
-
+        
     def get_voltage(self):
         """
         This function measures the voltage difference of the terminals for a selected channel.
@@ -277,6 +290,7 @@ class Device(EmptyDevice):
         """
         self.port.write("MEAS:VOLT?")
         answer = float(self.port.read())
+        
         return answer
 
     def set_current(self, current):
@@ -289,7 +303,7 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("CURR %1.4f" % float(current))
-
+        
     def get_current(self):
         """
         This function measures the current through the terminals for a selected channel.
@@ -298,6 +312,7 @@ class Device(EmptyDevice):
         """
         self.port.write("MEAS:CURR?")
         answer = float(self.port.read())
+        
         return answer
 
     def set_output_on(self):
@@ -350,6 +365,7 @@ class Device(EmptyDevice):
         """
         self.port.write("READ?")
         voltage, current = self.port.read().split(",")
+        
         return float(voltage), float(current)
 
     def set_voltage_range(self, voltage_range):
@@ -364,10 +380,13 @@ class Device(EmptyDevice):
         """
         if voltage_range == "20 V":
             self.port.write("SENS:VOLT:RANG 20")
+            
         elif voltage_range == "6 V":
             self.port.write("SENS:VOLT:RANG 6")
+            
         elif voltage_range == "Auto":
             self.port.write("SENS:VOLT:RANG:AUTO 1")
+
         else:
             raise Exception("The input voltage range is not valid.")
 
@@ -397,7 +416,7 @@ class Device(EmptyDevice):
             self.port.write("SENS:CURR:RANG:AUTO 1")
         else:
             raise Exception("The input current range is not valid.")
-
+            
     def set_nplc(self, nplc):
         """
         This function sets the number of power line cycles value. high NPLC means slow integration/speed and vice versa.
@@ -407,7 +426,6 @@ class Device(EmptyDevice):
             None
         """
         self.port.write("NPLC %0.1f" % nplc)
-
 
 if __name__ == "__main__":
 

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -278,6 +278,9 @@ class Device(EmptyDevice):
         Returns:
             None
         """
+
+        # set channel is often used in the driver to change the activated driver before further commands are sent.
+        # This is why the model is checked here, because the NGU model does not seem to understand the INST:OUT command.
         if self.model != "NGU":
             self.port.write("INST:OUT%i" % int(channel))
 

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -131,15 +131,24 @@ class Device(EmptyDevice):
             self.set_voltage(self.protection)
 
         # Speed
+        # NPLC settings for model NGU are
+        # 0, 5, 10, 50 and 100
+        # TODO: the entire Speed section needs a revision as the NPLC settings are only known for the NGU series
         if self.speed == "Fast":
             if self.model == "NGU":
                 self.set_nplc(0)
             else:
                 self.set_nplc(0.1)
         if self.speed == "Medium":
-            self.set_nplc(1)
+            if self.model == "NGU":
+                self.set_nplc(5)
+            else:
+                self.set_nplc(1)  # TODO: check whether other models support 1
         if self.speed == "Slow":
-            self.set_nplc(10)
+            if self.model == "NGU":
+                self.set_nplc(10)
+            else:
+                self.set_nplc(10)  # TODO: check whether other models support 10
 
     def unconfigure(self):
 

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -76,7 +76,7 @@ class Device(EmptyDevice):
             "Compliance": 5.0,
             "Range": ["Auto", "10 µA", "1 mA", "10 mA", "100 mA", "3 A", "10 A"],
             "RangeVoltage": ["Auto", "20 V", "6 V"],
-            "Speed": ["Fast", "Medium", "Slow"],
+            "Speed": ["Very fast", "Fast", "Medium", "Slow", "Very slow"],
             # "4wire": False,
         }
 
@@ -131,22 +131,31 @@ class Device(EmptyDevice):
             self.set_voltage(self.protection)
 
         # Speed
-        # NPLC settings for model NGU are
-        # 0, 5, 10, 50 and 100
+        # Possible NPLC settings for model NGU are 0, 5, 10, 50 and 100
         # TODO: the entire Speed section needs a revision as the NPLC settings are only known for the NGU series
-        if self.speed == "Fast":
+        if self.speed == "Very fast":
             if self.model == "NGU":
                 self.set_nplc(0)
             else:
-                self.set_nplc(0.1)
-        if self.speed == "Medium":
+                self.set_nplc(0)  # TODO: check whether other models support 0
+        elif self.speed == "Fast":
             if self.model == "NGU":
                 self.set_nplc(5)
             else:
-                self.set_nplc(1)  # TODO: check whether other models support 1
-        if self.speed == "Slow":
+                self.set_nplc(0.1)  # TODO: check whether other models support 0.1
+        elif self.speed == "Medium":
             if self.model == "NGU":
                 self.set_nplc(10)
+            else:
+                self.set_nplc(1)  # TODO: check whether other models support 1
+        elif self.speed == "Slow":
+            if self.model == "NGU":
+                self.set_nplc(50)
+            else:
+                self.set_nplc(10)  # TODO: check whether other models support 10
+        elif self.speed == "Very slow":
+            if self.model == "NGU":
+                self.set_nplc(100)
             else:
                 self.set_nplc(10)  # TODO: check whether other models support 10
 

--- a/src/SMU-Rohde&Schwarz_NGx/main.py
+++ b/src/SMU-Rohde&Schwarz_NGx/main.py
@@ -5,7 +5,7 @@
 #
 # MIT License
 # 
-# Copyright (c) 2022-2023 SweepMe! GmbH (sweep-me.net)
+# Copyright (c) 2022-2024 SweepMe! GmbH (sweep-me.net)
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,9 +25,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# SweepMe! device class
-# Type: SMU
-# Device: Rohde&Schwarz NGx
+# SweepMe! driver
+# * Module: SMU
+# * Instrument: Rohde&Schwarz NGx
 
 import time
 
@@ -63,14 +63,9 @@ class Device(EmptyDevice):
         self.port_types = ["COM", "USBTMC", "GPIB", "TCPIP"]
 
         self.port_properties = {"timeout": 1,
-                                # "delay": 0.05,
-                                # "Exception": False,
                                 }
 
-    #       self.commands = {
-    #                      "Voltage in V" : "VOLT",
-    #                      "Current in A" : "CURR",
-    #                      }
+        self.model = None
 
     def set_GUIparameter(self):
 
@@ -104,15 +99,29 @@ class Device(EmptyDevice):
                 self.port.port.write_termination = '\n'
                 self.port.port.read_termination = '\n'
 
-    def initialize(self):
+        # we do identification in connect as knowing the model is essential for further communication, e.g. because
+        # commands like set_channel do not work for NGU series
         identifier = self.get_identification()
         #print("Identifier:", identifier)  # can be used to check the instrument
+
+        if identifier.find("NGU") > 0:
+            self.model = "NGU"
+
+    def initialize(self):
+
         self.reset_instrument()
 
     def configure(self):
+
+        # Range
         self.set_voltage_range(self.voltage_range)
         self.set_current_range(self.current_range)
-        self.set_channel(self.channel)
+
+        # Channel
+        if self.model != "NGU":
+            self.set_channel(self.channel)
+
+        # Source
         if self.source.startswith("Voltage"):
             self.set_current_limit(self.protection)
             self.set_voltage(0.0)
@@ -121,6 +130,8 @@ class Device(EmptyDevice):
             self.set_voltage_limit(self.protection)
             self.set_current(0.0)
             self.set_voltage(self.protection)
+
+        # Speed
         if self.speed == "Fast":
             if self.model == "NGU":
                 self.set_nplc(0)
@@ -185,8 +196,6 @@ class Device(EmptyDevice):
         """
         self.port.write("*IDN?")
         answer = self.port.read()
-        if answer.find("NGU") > 0:
-            self.model = "NGU"
         
         return answer
 
@@ -262,14 +271,15 @@ class Device(EmptyDevice):
         """
         This function selects a channel as the active channel of the instrument. Then the channel does not need to be
         specified anymore with other commands.
+
+        It seems that this commands does not work with the NGU series
         Args:
             channel: int
 
         Returns:
             None
         """
-        if self.model != "NGU":
-            self.port.write("INST:OUT%i" % int(channel))
+        self.port.write("INST:OUT%i" % int(channel))
 
     def set_voltage(self, voltage):
         """


### PR DESCRIPTION
The original driver caused two SCPI errors that have been fixed by identifying the model via "*ID?" and adjusting the code accordingly via IF statements.

Modifications for NGU models:
- fastest NPLC is defined as "0" instead of "0.1" and needed for its "FastLog" capability
- the ""INST:OUT" command for selecting an output is not only unnecessary as this model is a single channel SMU; it is also rejected by the NGU in form of an SCPI command error. While the command is mentioned in the handbook in just one location within an example code, the command itself is not included.

The driver worked flawless without these modifications and all errors might have been went by unnoticed if the SCPI error beep was deactivated and the fastest NPLC setting was never used.