### PR TITLE
Add delay to Solartron_70x1

### DIFF
--- a/src/Logger-Solartron_70x1/main.py
+++ b/src/Logger-Solartron_70x1/main.py
@@ -54,6 +54,7 @@ class Device(EmptyDevice):
 
         self.port_properties = {
             "timeout": 22,  # needed for 1000 NPLC; adjust if 1000 NPLC are not needed
+            "delay": 0.05,
         }
 
         # this dictionary connects modes to commands. The modes will be displayed to the user in the field 'Mode'


### PR DESCRIPTION
Add a delay to the logger driver as it sometimes measures too fast at 4.5 digits.
See discussion here: https://forum.sweep-me.net/t/solartron-70x1-logger-dmm-driver-released/104/2