### PR TITLE
Bugfix: Keithley 2450 timeout

### DIFF
--- a/src/SMU-Keithley_2450/main.py
+++ b/src/SMU-Keithley_2450/main.py
@@ -155,6 +155,9 @@ class Device(EmptyDevice):
                 self.port.write("smu.measure.filter.count = 1")
                 self.port.write("smu.measure.filter.enable = smu.OFF")
 
+            # Create a buffer to store the measured data
+            self.port.write("data = buffer.make(10)")
+
         if self.source.startswith("Voltage"):
             self.source_volt()
 
@@ -225,7 +228,8 @@ class Device(EmptyDevice):
             self.port.write("READ?")
 
         elif self.language == "TSP":
-            self.port.write("data = buffer.make(10)")
+            # Clear the buffer before the measurement
+            self.port.write("data.clear()")
             self.port.write("smu.measure.read(data)")
 
             # way to directly trigger sending the reading:


### PR DESCRIPTION
Fix a bug where too many buffer instances were defined and the device crashes after prolonged measurements.
Now create a single buffer in configure and clear it before each measurement.