### PR TITLE
LCRmeter Metrohm Reactance

### DIFF
--- a/src/LCRmeter-Metrohm_AutolabPGSTAT/main.py
+++ b/src/LCRmeter-Metrohm_AutolabPGSTAT/main.py
@@ -354,10 +354,10 @@ class Device(EmptyDevice):
         Ztotal = Fra.Modulus[0]
         Phase = Fra.Phase[0]
         Resistance R: Zreal = Fra.Real[0]
-        Reactance X: Zimag = Fra.Imaginary[0]
+        Reactance X: Zimag = - Fra.Imaginary[0]  # Nova handles the reactance as negative
         """
         resistance = self.Fra.Real[0]
-        reactance = self.Fra.Imaginary[0]
+        reactance = -self.Fra.Imaginary[0]
         return resistance, reactance
 
     def measure_dc_bias(self) -> float:


### PR DESCRIPTION
Add a factor of -1 because the Nova SDK handles reactance with negative sign