### PR TITLE
Red Pitaya driver update

### DIFF
--- a/src/Scope-RedPitaya_STEMlab/libs/redpitaya_scpi.py
+++ b/src/Scope-RedPitaya_STEMlab/libs/redpitaya_scpi.py
@@ -114,13 +114,13 @@ class scpi (object):
                     exit(1)
 
 
-# IEEE Mandated Commands
+    # IEEE Mandated Commands
 
     def cls(self):
         """Clear Status Command"""
         return self.tx_txt('*CLS')
 
-    def ese(self, value: int):
+    def ese(self, value):
         """Standard Event Status Enable Command"""
         return self.tx_txt(f'*ESE {value}')
 
@@ -148,9 +148,9 @@ class scpi (object):
         """Reset Command"""
         return self.tx_txt('*RST')
 
-    def sre(self, value: int):
+    def sre(self):
         """Service Request Enable Command"""
-        return self.tx_txt('*SRE {value}')
+        return self.tx_txt('*SRE')
 
     def sre_q(self):
         """Service Request Enable Query"""
@@ -160,12 +160,11 @@ class scpi (object):
         """Read Status Byte Query"""
         return self.txrx_txt('*STB?')
 
-# :SYSTem
-
+    # :SYSTem
     def err_c(self):
         """Error count."""
-        return self.txrx_txt('SYST:ERR:COUN?')
+        return self.txrx_txt('SYSTem:ERRor:COUNt?')
 
     def err_n(self):
         """Error next."""
-        return self.txrx_txt('SYST:ERR:NEXT?')
+        return self.txrx_txt('SYSTem:ERRor:NEXT?')

--- a/src/Scope-RedPitaya_STEMlab/libs/redpitaya_scpi.py
+++ b/src/Scope-RedPitaya_STEMlab/libs/redpitaya_scpi.py
@@ -1,9 +1,11 @@
-"""SCPI access to Red Pitaya."""
+"""Python SCPI access to Red Pitaya. The core file contains only the absolutely necessary functionality and libraries."""
 
 import socket
+import struct
 
-__author__ = "Luka Golinar, Iztok Jeras"
-__copyright__ = "Copyright 2015, Red Pitaya"
+__author__ = "Luka Golinar, Iztok Jeras, Miha Gjura"
+__copyright__ = "Copyright 2025, Red Pitaya"
+__OS_version__ = "2.00 and above"            # The core file should be compatible even with older OS versions.
 
 class scpi (object):
     """SCPI class used to access Red Pitaya over an IP network."""
@@ -11,7 +13,7 @@ class scpi (object):
 
     def __init__(self, host, timeout=None, port=5000):
         """Initialize object and open IP connection.
-        Host IP should be a string in parentheses, like '192.168.1.100'.
+        Host IP should be a string in parentheses, like '192.168.1.100' or 'rp-xxxxxx.local'.
         """
         self.host    = host
         self.port    = port
@@ -26,7 +28,7 @@ class scpi (object):
             self._socket.connect((host, port))
 
         except socket.error as e:
-            print('SCPI >> connect({:s}:{:d}) failed: {:s}'.format(host, port, e))
+            print('SCPI >> connect({!s:s}:{:d}) failed: {!s:s}'.format(host, port, e))
 
     def __del__(self):
         if self._socket is not None:
@@ -41,43 +43,76 @@ class scpi (object):
         """Receive text string and return it after removing the delimiter."""
         msg = ''
         while 1:
-            chunk = self._socket.recv(chunksize + len(self.delimiter)).decode('utf-8') # Receive chunk size of 2^n preferably
+            chunk = self._socket.recv(chunksize).decode('utf-8') # Receive chunk size of 2^n preferably
             msg += chunk
-            if (len(chunk) and chunk[-2:] == self.delimiter):
-                break
-        return msg[:-2]
+            if (len(msg) >= 2 and msg[-2:] == self.delimiter):
+                return msg[:-2]
+
+    def rx_txt_check_error(self, chunksize = 4096,stop = True):
+        msg = self.rx_txt(chunksize)
+        self.check_error(stop)
+        return msg
 
     def rx_arb(self):
-        numOfBytes = 0
         """ Recieve binary data from scpi server"""
-        str=''
-        while (len(str) != 1):
-            str = (self._socket.recv(1))
-        if not (str == '#'):
+        numOfBytes = 0
+        data=b''
+        while len(data) != 1:
+            data = self._socket.recv(1)
+        if data != b'#':
             return False
-        str=''
-        while (len(str) != 1):
-            str = (self._socket.recv(1))
-        numOfNumBytes = int(str)
-        if not (numOfNumBytes > 0):
+        data=b''
+
+        while len(data) != 1:
+            data = self._socket.recv(1)
+        numOfNumBytes = int(data)
+        if numOfNumBytes <= 0:
             return False
-        str=''
-        while (len(str) != numOfNumBytes):
-            str += (self._socket.recv(1))
-        numOfBytes = int(str)
-        str=''
-        while (len(str) != numOfBytes):
-            str += (self._socket.recv(1))
-        return str
+        data=b''
+
+        while len(data) != numOfNumBytes:
+            data += (self._socket.recv(1))
+        numOfBytes = int(data)
+        data=b''
+
+        while len(data) < numOfBytes:
+            r_size = min(numOfBytes - len(data),4096)
+            data += (self._socket.recv(r_size))
+
+        self._socket.recv(2) # recive \r\n
+
+        return data
+
+    def rx_arb_check_error(self,stop = True):
+        data = self.rx_arb()
+        self.check_error(stop)
+        return data
 
     def tx_txt(self, msg):
         """Send text string ending and append delimiter."""
-        return self._socket.send((msg + self.delimiter).encode('utf-8'))
+        return self._socket.sendall((msg + self.delimiter).encode('utf-8')) # was send(().encode('utf-8'))
+
+    def tx_txt_check_error(self, msg,stop = True):
+        self.tx_txt(msg)
+        self.check_error(stop)
 
     def txrx_txt(self, msg):
         """Send/receive text string."""
         self.tx_txt(msg)
         return self.rx_txt()
+
+    def check_error(self,stop = True):
+        res = int(self.stb_q())
+        if (res & 0x4):
+            while 1:
+                err = self.err_n()
+                if (err.startswith('0,')):
+                    break
+                print(err)
+                n = err.split(",")
+                if (len(n) > 0 and stop and int(n[0]) > 9500):
+                    exit(1)
+
 
 # IEEE Mandated Commands
 
@@ -87,7 +122,7 @@ class scpi (object):
 
     def ese(self, value: int):
         """Standard Event Status Enable Command"""
-        return self.tx_txt('*ESE {}'.format(value))
+        return self.tx_txt(f'*ESE {value}')
 
     def ese_q(self):
         """Standard Event Status Enable Query"""
@@ -113,9 +148,9 @@ class scpi (object):
         """Reset Command"""
         return self.tx_txt('*RST')
 
-    def sre(self):
+    def sre(self, value: int):
         """Service Request Enable Command"""
-        return self.tx_txt('*SRE')
+        return self.tx_txt('*SRE {value}')
 
     def sre_q(self):
         """Service Request Enable Query"""
@@ -129,8 +164,8 @@ class scpi (object):
 
     def err_c(self):
         """Error count."""
-        return rp.txrx_txt('SYST:ERR:COUN?')
+        return self.txrx_txt('SYST:ERR:COUN?')
 
-    def err_c(self):
+    def err_n(self):
         """Error next."""
-        return rp.txrx_txt('SYST:ERR:NEXT?')
+        return self.txrx_txt('SYST:ERR:NEXT?')

--- a/src/Scope-RedPitaya_STEMlab/main.py
+++ b/src/Scope-RedPitaya_STEMlab/main.py
@@ -30,6 +30,7 @@
 # SweepMe! device class
 # Type: Scope
 # Device: Red pitaya STEMlab
+# Red Pitaya OS: 2.05-37
 
 # TODO
 #-> comments
@@ -171,7 +172,7 @@ class Device(EmptyDevice):
 
         self.reset_acquisition()  # Reset Device
 
-        self.port.write("ACQ:DATA:UNITS VOLTS")  # set Units
+        self.port.write("ACQ:DATA:Units VOLTS")  # set Units
         
         self.port.write("ACQ:BUF:SIZE?")  # get buffersize from device
         self.buffersize = int(self.port.read())
@@ -241,14 +242,13 @@ class Device(EmptyDevice):
                 elif time.time()-self.starttime > self.triggertimeout:
                     msg = "Red Pitaya Scope Trigger timeout!"
                     raise Exception(msg)
-                    
-            # https://redpitaya.readthedocs.io/en/latest/appsFeatures/examples/acquisition/acqRF-exm1.html#scpi-code-examples        
+
             # OS 2.00-18 or higher
-            # while True:
-                # self.port.write("ACQ:TRig:FILL?")
-                # buffer_fill = self.port.read()
-                # if buffer_fill == "1":
-                    # break
+            while True:
+                self.port.write("ACQ:TRig:FILL?")
+                buffer_fill = self.port.read()
+                if buffer_fill == "1":
+                    break
 
             # Waiting for the buffer to fill
             # self.sleeptime = self.timerange - self.triggerdelay + self.starttime - time.time()
@@ -279,7 +279,7 @@ class Device(EmptyDevice):
     
     def read_data(self):
         for i in range(len(self.channels)):
-            self.port.write("ACQ:SOUR{0}:DATA:OLD:N? {1}".format(self.channels[i], self.read_samples))
+            self.port.write("ACQ:SOUR{0}:DATA:Old:N? {1}".format(self.channels[i], self.read_samples))    #! Check the intended functionality
             self.buffer = self.port.read()
             try:
                 self.data = list(map(float, self.buffer.strip('{}\n\r').replace("  ", "").split(',')))
@@ -294,7 +294,7 @@ class Device(EmptyDevice):
     def trigger_settings(self):
         # create trigger command
         self.triggersource = self.commands[self.triggermode]
-        if self.triggersource != "NOW" and self.triggersource != "DISABLED":
+        if self.triggersource != "NOW" and self.triggersource != "DISABLED":    #!
             self.triggersource += self.commands[self.triggerslope]
 
         self.triggerdelaysamples = int(self.triggerdelay*self.real_samplerate+self.buffersize*0.5)
@@ -329,31 +329,31 @@ class Device(EmptyDevice):
         # Shows current status of RedPitayas settings
         self.port.write("ACQ:DEC {0}".format(self.decimation))                      # set decimation
         self.port.write("ACQ:AVG {0}".format(self.commands[self.acquisiton]))       # set decimation average
-        self.port.write("ACQ:TRIG {}".format(self.triggersource))                   # set trigger source
+        self.port.write("ACQ:TRig {}".format(self.triggersource))                   # set trigger source
         
         if self.triggersource != "NOW" and self.triggersource != "DISABLED":
-            self.port.write("ACQ:TRIG:LEV {0}".format(self.triggerlevel))           # set trigger level
-            self.port.write("ACQ:TRIG:HYST {0}".format(self.triggerhysteresis))     # set trigger hysteresis
-            self.port.write("ACQ:TRIG:DLY {0}".format(self.triggerdelaysamples))    # set trigger delay
+            self.port.write("ACQ:TRig:LEV {0}".format(self.triggerlevel))           # set trigger level
+            self.port.write("ACQ:TRig:HYST {0}".format(self.triggerhysteresis))     # set trigger hysteresis
+            self.port.write("ACQ:TRig:DLY {0}".format(self.triggerdelaysamples))    # set trigger delay
 
     def settings_status(self):
-        self.port.write("ACQ:DATA:UNITS?")                  # Data units
+        self.port.write("ACQ:DATA:Units?")                  # Data units
         print("Data Units:", self.port.read())
         self.port.write("ACQ:DEC?")                         # Decimation
         print("Decimation:", self.port.read())
         self.port.write("ACQ:AVG?")                         # Decimation averaging
         print("Averaging:", self.port.read())
-        self.port.write("ACQ:TRIG:LEV?")                    # Trigger Level
+        self.port.write("ACQ:TRig:LEV?")                    # Trigger Level
         print("Trigger Level:", self.port.read())
-        self.port.write("ACQ:TRIG:HYST?")                   # Trigger Hysteresis
+        self.port.write("ACQ:TRig:HYST?")                   # Trigger Hysteresis
         print("Trigger Hysteresis:", self.port.read())
-        self.port.write("ACQ:TRIG:DLY?")                    # Trigger Delay
+        self.port.write("ACQ:TRig:DLY?")                    # Trigger Delay
         print("Trigger Delay:", self.port.read())
         self.port.write("ACQ:SOUR1:GAIN?")                  # Channel 1 Gain
         print("Channel 1 Gain:", self.port.read())
         self.port.write("ACQ:SOUR2:GAIN?")                  # Channel 2 Gain
         print("Channel 2 Gain:", self.port.read())
-        self.port.write("ACQ:TRIG:STAT?")                   # Trigger status
+        self.port.write("ACQ:TRig:STAT?")                   # Trigger status
         print("Trigger Status:", self.port.read())
 
     def get_identification(self):
@@ -361,7 +361,7 @@ class Device(EmptyDevice):
         return self.port.read()
 
     def get_system_version(self):
-        self.port.write("SYST:VERS?")
+        self.port.write("SYSTem:VERS?")        #!
         return self.port.read()
         
     def start_acquisition(self):
@@ -382,7 +382,7 @@ class Device(EmptyDevice):
                 -> "TD" if the measurement was triggered
         """
         
-        self.port.write("ACQ:TRIG:STAT?")
+        self.port.write("ACQ:TRig:STAT?")
         return self.port.read()
         
     def set_average(self, state):

--- a/src/Signal-RedPitaya_STEMlab/libs/redpitaya_scpi.py
+++ b/src/Signal-RedPitaya_STEMlab/libs/redpitaya_scpi.py
@@ -120,7 +120,7 @@ class scpi (object):
         """Clear Status Command"""
         return self.tx_txt('*CLS')
 
-    def ese(self, value: int):
+    def ese(self, value):
         """Standard Event Status Enable Command"""
         return self.tx_txt(f'*ESE {value}')
 
@@ -148,9 +148,9 @@ class scpi (object):
         """Reset Command"""
         return self.tx_txt('*RST')
 
-    def sre(self, value: int):
+    def sre(self):
         """Service Request Enable Command"""
-        return self.tx_txt('*SRE {value}')
+        return self.tx_txt('*SRE')
 
     def sre_q(self):
         """Service Request Enable Query"""
@@ -161,10 +161,13 @@ class scpi (object):
         return self.txrx_txt('*STB?')
 
 # :SYSTem
-
     def err_c(self):
         """Error count."""
-        return self.txrx_txt('SYST:ERR:COUN?')
+        return self.txrx_txt('SYSTem:ERRor:COUNt?')
+
+    def err_n(self):
+        """Error next."""
+        return self.txrx_txt('SYSTem:ERRor:NEXT?')
 
     def err_n(self):
         """Error next."""

--- a/src/Signal-RedPitaya_STEMlab/libs/redpitaya_scpi.py
+++ b/src/Signal-RedPitaya_STEMlab/libs/redpitaya_scpi.py
@@ -1,9 +1,11 @@
-"""SCPI access to Red Pitaya."""
+"""Python SCPI access to Red Pitaya. The core file contains only the absolutely necessary functionality and libraries."""
 
 import socket
+import struct
 
-__author__ = "Luka Golinar, Iztok Jeras"
-__copyright__ = "Copyright 2015, Red Pitaya"
+__author__ = "Luka Golinar, Iztok Jeras, Miha Gjura"
+__copyright__ = "Copyright 2025, Red Pitaya"
+__OS_version__ = "2.00 and above"            # The core file should be compatible even with older OS versions.
 
 class scpi (object):
     """SCPI class used to access Red Pitaya over an IP network."""
@@ -11,7 +13,7 @@ class scpi (object):
 
     def __init__(self, host, timeout=None, port=5000):
         """Initialize object and open IP connection.
-        Host IP should be a string in parentheses, like '192.168.1.100'.
+        Host IP should be a string in parentheses, like '192.168.1.100' or 'rp-xxxxxx.local'.
         """
         self.host    = host
         self.port    = port
@@ -26,7 +28,7 @@ class scpi (object):
             self._socket.connect((host, port))
 
         except socket.error as e:
-            print('SCPI >> connect({:s}:{:d}) failed: {:s}'.format(host, port, e))
+            print('SCPI >> connect({!s:s}:{:d}) failed: {!s:s}'.format(host, port, e))
 
     def __del__(self):
         if self._socket is not None:
@@ -41,43 +43,76 @@ class scpi (object):
         """Receive text string and return it after removing the delimiter."""
         msg = ''
         while 1:
-            chunk = self._socket.recv(chunksize + len(self.delimiter)).decode('utf-8') # Receive chunk size of 2^n preferably
+            chunk = self._socket.recv(chunksize).decode('utf-8') # Receive chunk size of 2^n preferably
             msg += chunk
-            if (len(chunk) and chunk[-2:] == self.delimiter):
-                break
-        return msg[:-2]
+            if (len(msg) >= 2 and msg[-2:] == self.delimiter):
+                return msg[:-2]
+
+    def rx_txt_check_error(self, chunksize = 4096,stop = True):
+        msg = self.rx_txt(chunksize)
+        self.check_error(stop)
+        return msg
 
     def rx_arb(self):
-        numOfBytes = 0
         """ Recieve binary data from scpi server"""
-        str=''
-        while (len(str) != 1):
-            str = (self._socket.recv(1))
-        if not (str == '#'):
+        numOfBytes = 0
+        data=b''
+        while len(data) != 1:
+            data = self._socket.recv(1)
+        if data != b'#':
             return False
-        str=''
-        while (len(str) != 1):
-            str = (self._socket.recv(1))
-        numOfNumBytes = int(str)
-        if not (numOfNumBytes > 0):
+        data=b''
+
+        while len(data) != 1:
+            data = self._socket.recv(1)
+        numOfNumBytes = int(data)
+        if numOfNumBytes <= 0:
             return False
-        str=''
-        while (len(str) != numOfNumBytes):
-            str += (self._socket.recv(1))
-        numOfBytes = int(str)
-        str=''
-        while (len(str) != numOfBytes):
-            str += (self._socket.recv(1))
-        return str
+        data=b''
+
+        while len(data) != numOfNumBytes:
+            data += (self._socket.recv(1))
+        numOfBytes = int(data)
+        data=b''
+
+        while len(data) < numOfBytes:
+            r_size = min(numOfBytes - len(data),4096)
+            data += (self._socket.recv(r_size))
+
+        self._socket.recv(2) # recive \r\n
+
+        return data
+
+    def rx_arb_check_error(self,stop = True):
+        data = self.rx_arb()
+        self.check_error(stop)
+        return data
 
     def tx_txt(self, msg):
         """Send text string ending and append delimiter."""
-        return self._socket.send((msg + self.delimiter).encode('utf-8'))
+        return self._socket.sendall((msg + self.delimiter).encode('utf-8')) # was send(().encode('utf-8'))
+
+    def tx_txt_check_error(self, msg,stop = True):
+        self.tx_txt(msg)
+        self.check_error(stop)
 
     def txrx_txt(self, msg):
         """Send/receive text string."""
         self.tx_txt(msg)
         return self.rx_txt()
+
+    def check_error(self,stop = True):
+        res = int(self.stb_q())
+        if (res & 0x4):
+            while 1:
+                err = self.err_n()
+                if (err.startswith('0,')):
+                    break
+                print(err)
+                n = err.split(",")
+                if (len(n) > 0 and stop and int(n[0]) > 9500):
+                    exit(1)
+
 
 # IEEE Mandated Commands
 
@@ -87,7 +122,7 @@ class scpi (object):
 
     def ese(self, value: int):
         """Standard Event Status Enable Command"""
-        return self.tx_txt('*ESE {}'.format(value))
+        return self.tx_txt(f'*ESE {value}')
 
     def ese_q(self):
         """Standard Event Status Enable Query"""
@@ -113,9 +148,9 @@ class scpi (object):
         """Reset Command"""
         return self.tx_txt('*RST')
 
-    def sre(self):
+    def sre(self, value: int):
         """Service Request Enable Command"""
-        return self.tx_txt('*SRE')
+        return self.tx_txt('*SRE {value}')
 
     def sre_q(self):
         """Service Request Enable Query"""
@@ -129,8 +164,8 @@ class scpi (object):
 
     def err_c(self):
         """Error count."""
-        return rp.txrx_txt('SYST:ERR:COUN?')
+        return self.txrx_txt('SYST:ERR:COUN?')
 
-    def err_c(self):
+    def err_n(self):
         """Error next."""
-        return rp.txrx_txt('SYST:ERR:NEXT?')
+        return self.txrx_txt('SYST:ERR:NEXT?')

--- a/src/Signal-RedPitaya_STEMlab/main.py
+++ b/src/Signal-RedPitaya_STEMlab/main.py
@@ -29,8 +29,8 @@
 
 # SweepMe! device class
 # Type: Signal
-# Device: Red pitaya STEMlab
-
+# Device: Red Pitaya STEMlab
+# Red Pitaya OS: 2.05-37
 
 import numpy as np
 import time
@@ -65,7 +65,6 @@ class Device(EmptyDevice):
             "Internal": "INT", 
             "External NE": "EXT_NE", 
             "External PE": "EXT_PE", 
-            "Immediately": "IMM", 
             "Gated": "GATED",
             }
                         
@@ -207,12 +206,8 @@ class Device(EmptyDevice):
     def trigger_ready(self):
         
         # set trigger
-        if self.triggertypes[self.triggertype] == "IMM":
-            self.port.write('SOUR{0}:TRIG:IMM'.format(self.channel))
-            self.port.write('SOUR{0}:BURS:STAT CONTINUOUS'.format(self.channel))
-        else:
-            self.port.write('SOUR{0}:TRIG:SOUR {1}'.format(self.channel, self.triggertypes[self.triggertype]))
-            self.port.write('SOUR{0}:BURS:STAT CONTINUOUS'.format(self.channel))
+        self.port.write('SOUR{0}:TRig:SOUR {1}'.format(self.channel, self.triggertypes[self.triggertype]))
+        self.port.write('SOUR{0}:BURS:STAT CONTINUOUS'.format(self.channel))
 
         # set burst mode (after trigger settings!)
         self.set_burst_mode()                                          # set Burst mode
@@ -221,6 +216,9 @@ class Device(EmptyDevice):
         self.port.write('OUTPUT{0}:STATE ON'.format(self.channel))
         # self.port.write('OUTPUT{0}:STATE?'.format(self.channel))
         # self.port.read()
+
+        if (self.triggertype == "INT"):                                # Trigger generator if internal trigger is selected
+            self.port.write('SOUR{0}:TRig:INT'.format(self.channel))
 
     def call(self):
         if self.sweep_mode != "None":
@@ -329,8 +327,8 @@ class Device(EmptyDevice):
         self.port.write('SOUR{0}:BURS:STAT {1}'.format(self.channel, self.operationmodes[self.operationmode]))  # set OperationMode
         if self.operationmodes[self.operationmode] != "CONTINUOUS":
             self.burstperiod = 10**6 * (self.periodnumber / self.frequency + self.burstdelay)
-            self.port.write('SOUR{0}:BURS:INT:PER {1}'.format(self.channel, self.burstperiod))          # set total Burst period (signal + delay)
-            self.port.write('SOUR{0}:BURS:NOR {1}'.format(self.channel, self.burstnumber))            # set number of Periods in one Burst
+            self.port.write('SOUR{0}:BURS:INT:PER {1}'.format(self.channel, self.burstperiod))            # set total Burst period (signal + delay)
+            self.port.write('SOUR{0}:BURS:NOR {1}'.format(self.channel, self.burstnumber))                # set number of Periods in one Burst
             self.port.write('SOUR{0}:BURS:NCYC {1}'.format(self.channel, self.periodnumber))              # set number of repeated Bursts
 
     def get_identification(self):
@@ -351,6 +349,6 @@ class Device(EmptyDevice):
         return self.port.read()
      
     def get_system_version(self):
-        self.port.write("SYST:VERS?")
+        self.port.write("SYSTem:VERS?")
         return self.port.read()
     


### PR DESCRIPTION
List of updates:
- Updated the redpitaya_scpi.py to the latest version
- Updated SCPI commands to work with the latest OS 2.05-37 (it will not be compatible with 1.04 OS versions).
- Removed obsolete functionality (immediate trigger in acquisition)
- Added generator trigger command to start the generation after enabling it.

The driver must be tested before fully merged with the main branch!

My questions (relate to lines labelled with "#!":
- Acquisition data acquire - maybe we should schedule another call regarding this just to get the correct idea to what kind of data you want to capture. ACQ:SOUR{0}:DATA:Old:N? returns the oldest N samples in the buffer, which are usually before the triggering moment and can be impacted negatively by trigger being in the middle of the buffer (see this description [here](https://redpitaya.readthedocs.io/en/latest/appsFeatures/introAcqGen.html#scpi-commands).
- "Now" trigger can incorrectly show the pre-trigger data, especially on high decimation settings with not enough time to fill the buffer.
- I will have to double-check if the SYSTem:VERS command exists.
-  We can try to include additional functionality available through SCPI commands. We could also increase the interface speed by moving on to Python API commands, which are faster, but would require us to establish an SSH connection with the device (and completely rewrite the driver).

Let me know if you want to keep the 1.04 OS compatibility, but I would suggest moving to 2.00 OS (Red Pitaya OS version).