### PR TITLE
Refactor multichannel drivers: replace self.multichannel with Channel GUI parameter

### DIFF
--- a/src/SMU-Agilent_N6705A/main.py
+++ b/src/SMU-Agilent_N6705A/main.py
@@ -53,16 +53,11 @@ class Device(EmptyDevice):
                             - 200 uA measurement range
                     """
 
-    multichannel = ["CH1", "CH2", "CH3", "CH4"]
-
     def __init__(self):
 
         super().__init__()
 
         self.shortname = "Agilent N6705A"
-
-        # remains here for compatibility with v1.5.3
-        self.multichannel = ["CH1", "CH2", "CH3", "CH4"]
 
         self.variables = ["Voltage", "Current"]
         self.units = ["V", "A"]
@@ -96,6 +91,7 @@ class Device(EmptyDevice):
     def set_GUIparameter(self):
         GUIparameter = {
             "SweepMode": ["Voltage [V]", "Current [A]"],
+            "Channel": ["CH1", "CH2", "CH3", "CH4"],
             "Range": list(self.current_ranges.keys()),
             "RangeVoltage": list(self.voltage_ranges.keys()),
             "Compliance": 100e-6,
@@ -110,9 +106,7 @@ class Device(EmptyDevice):
         self.vrange = self.voltage_ranges[parameter["RangeVoltage"]]
         self.irange = self.current_ranges[parameter["Range"]]
         self.average = parameter["Average"]
-
-        self.device = parameter['Device']
-        self.channel = self.device[-1]
+        self.channel = parameter["Channel"][-1]
 
     def initialize(self):
         self.port.port.read_termination = '\n'

--- a/src/Signal-Agilent_33600A/license.txt
+++ b/src/Signal-Agilent_33600A/license.txt
@@ -5,7 +5,7 @@ find those in the corresponding folders or contact the maintainer.
 
 MIT License
 
-Copyright (c) 2018-2020 Axel Fischer (sweep-me.net)
+Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Signal-Agilent_33600A/main.py
+++ b/src/Signal-Agilent_33600A/main.py
@@ -5,7 +5,7 @@
 #
 # MIT License
 # 
-# Copyright (c) 2018-2020 Axel Fischer (sweep-me.net)
+# Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,47 +24,65 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
+# SweepMe! driver
+# * Module: Signal
+# * Instrument: Agilent_33600A
 
-# SweepMe! device class
-# Type: Signal
-# Device: Agilent_33600A
+from typing import Any
 
-from EmptyDeviceClass import EmptyDevice
+from pysweepme.EmptyDeviceClass import EmptyDevice
+
 
 class Device(EmptyDevice):
 
     def __init__(self):
-    
+
         EmptyDevice.__init__(self)
-        
+
         self.port_manager = True
-        self.port_types = ['USB', 'GPIB']
-        self.port_identifications = ['Agilent Technologies,336', 'Agilent Technologies,335']
-        
+        self.port_types = ["USB", "GPIB"]
+        self.port_identifications = ["Agilent Technologies,336", "Agilent Technologies,335"]
+
         # to be defined by user
-        self.commands = {   "Sine":"SIN",
-                            "Square":"SQU", 
-                            "Ramp":"RAMP", 
-                            "Pulse":"PULS", 
-                            "Noise":"NOIS",
-                            "Triangle":"TRI",
-                            "DC":"DC", 
-                            "Arbitrary":"ARB", 
-                            "Period [s]":"PER",  
-                            "Frequency [Hz]":"FREQ", 
-                            "HiLevel [V]":"VOLT:HIGH",  
-                            "LoLevel [V]":"VOLT:LOW",
-                            "Amplitude [V]":"VOLT",
-                            "Offset [V]":"VOLT:OFFS",
-                        }
-        
+        self.commands = {"Sine": "SIN",
+                         "Square": "SQU",
+                         "Ramp": "RAMP",
+                         "Pulse": "PULS",
+                         "Noise": "NOIS",
+                         "Triangle": "TRI",
+                         "DC": "DC",
+                         "Arbitrary": "ARB",
+                         "Period in s": "PER",
+                         "Frequency in Hz": "FREQ",
+                         "HiLevel in V": "VOLT:HIGH",
+                         "LoLevel in V": "VOLT:LOW",
+                         "Amplitude in V": "VOLT",
+                         "Offset in V": "VOLT:OFFS",
+                         }
+
         self.waveform_standard_list = ["Sine", "Square", "Ramp", "Pulse", "Noise", "Triangle", "DC"]
 
-        self.plottype = [True] # True to plot data
-        self.savetype = [True] # True to save data
-        
-        
+        self.plottype = [True]  # True to plot data
+        self.savetype = [True]  # True to save data
+
+        # Measurement Parameters
+        self.channel: str = "1"
+        self.sweep_mode: str = "None"
+        self.waveform: str = "Sine"
+        self.period_frequency: str = "Frequency in Hz"
+        self.period_frequency_value:float = 1000
+        self.amplitude_hi_level: str = "Amplitude in V"
+        self.amplitude_hi_level_value:float = 1.0
+        self.offset_lo_level: str = "Offset in V"
+        self.offset_lo_level_value:float = 0.0
+        self.duty_cycle_pulse_width: str = "Duty cycle in %"
+        self.duty_cycle_pulse_width_value:float = 50
+        self.delay_phase: str = "Phase in deg"
+        self.delay_phase_value:float =  0
+        self.impedance: str = "High-Z"
+
         # These commands require Option 001, External Timebase Reference (see
         # page 258 for more information).
         # PHASe {<angle>|MINimum|MAXimum}
@@ -74,121 +92,110 @@ class Device(EmptyDevice):
         # PHASe:UNLock:ERRor:STATe?
         # UNIT:ANGLe {DEGree|RADian}
         # UNIT:ANGLe?
-        
-    def set_GUIparameter(self):
-        GUIparameter = {
-                        "SweepMode": ["Frequency [Hz]", "Period [s]", "Amplitude [V]", "HiLevel [V]", "Offset [V]", "LoLevel [V]", "Pulse width [s]", "Duty cycle [%]", "Delay [s]", "Phase [deg]", "None"],
-                        "Channel": ["CH1", "CH2"],
-                        "PeriodFrequency" : ["Frequency [Hz]", "Period [s]"],
-                        "PeriodFrequencyValue": 1000,
-                        "AmplitudeHiLevel" : ["Amplitude [V]", "HiLevel [V]"],
-                        "AmplitudeHiLevelValue": 1.0,
-                        "OffsetLoLevel" : ["Offset [V]", "LoLevel [V]"],
-                        "OffsetLoLevelValue": 0.0,
-                        "DelayPhase": ["Phase [deg]", "Delay [s]"],
-                        "DelayPhaseValue": 0,
-                        "DutyCyclePulseWidth": ["Duty cycle [%]", "Pulse width [s]"],
-                        "DutyCyclePulseWidthValue": 50,
-                        "Waveform" : ["Sine", "Square", "Ramp", "Pulse", "Noise", "Triangle", "DC", "Arbitrary: <file name>"],
-                        "Impedance": ["High-Z", "50 Ohm"],
-                        #"Trigger": ["Not supported yet"] 
-                        }
-        return GUIparameter
 
-        
-    def get_GUIparameter(self, parameter={}):
-        # could be part of the MeasClass
-        self.channel                  = parameter['Channel'][-1]
-        self.sweep_mode               = parameter['SweepMode'] 
-        self.waveform                 = parameter['Waveform'] 
-        self.periodfrequency          = parameter['PeriodFrequency' ]
-        self.periodfrequencyvalue     = float(parameter['PeriodFrequencyValue'])
-        self.amplitudehilevel         = parameter['AmplitudeHiLevel']
-        self.amplitudehilevelvalue    = float(parameter['AmplitudeHiLevelValue'])
-        self.offsetlolevel            = parameter['OffsetLoLevel']
-        self.offsetlolevelvalue       = float(parameter['OffsetLoLevelValue'])
-        self.dutycyclepulsewidth      = parameter['DutyCyclePulseWidth']
-        self.dutycyclepulsewidthvalue = float(parameter['DutyCyclePulseWidthValue'])
-        self.delayphase               = parameter['DelayPhase']
-        self.delayphasevalue          = float(parameter['DelayPhaseValue'])
-        self.impedance                = parameter['Impedance']
-        
-        
+    def update_gui_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Returns a dictionary with keys and values to generate GUI elements in the SweepMe! GUI."""
+        return {
+            "SweepMode": ["Frequency in Hz", "Period in s", "Amplitude in V", "HiLevel in V", "Offset in V",
+                          "LoLevel in V", "Pulse width in s", "Duty cycle in %", "Delay in s", "Phase in deg", "None"],
+            "Channel": ["1", "2"],
+            "PeriodFrequency": ["Frequency in Hz", "Period in s"],
+            "PeriodFrequencyValue": 1000,
+            "AmplitudeHiLevel": ["Amplitude in V", "HiLevel in V"],
+            "AmplitudeHiLevelValue": 1.0,
+            "OffsetLoLevel": ["Offset in V", "LoLevel in V"],
+            "OffsetLoLevelValue": 0.0,
+            "DelayPhase": ["Phase in deg", "Delay in s"],
+            "DelayPhaseValue": 0,
+            "DutyCyclePulseWidth": ["Duty cycle in %", "Pulse width in s"],
+            "DutyCyclePulseWidthValue": 50,
+            "Waveform": ["Sine", "Square", "Ramp", "Pulse", "Noise", "Triangle", "DC", "Arbitrary: <file name>"],
+            "Impedance": ["High-Z", "50 Ohm"],
+            # "Trigger": ["Not supported yet"]
+        }
+
+    def apply_gui_parameters(self, parameters: dict[str, Any]) -> None:
+        """Receive the values of the GUI parameters that were set by the user in the SweepMe! GUI."""
+        self.channel = parameters.get("Channel", "1")
+        self.sweep_mode = parameters.get("SweepMode", "None")
+        self.waveform = parameters.get("Waveform", "Sine")
+        self.period_frequency = parameters.get("PeriodFrequency", "Frequency in Hz")
+        self.period_frequency_value = float(parameters.get("PeriodFrequencyValue", 1000))
+        self.amplitude_hi_level = parameters.get("AmplitudeHiLevel", "Amplitude in V")
+        self.amplitude_hi_level_value = float(parameters.get("AmplitudeHiLevelValue", 1.0))
+        self.offset_lo_level = parameters.get("OffsetLoLevel", "Offset in V")
+        self.offset_lo_level_value = float(parameters.get("OffsetLoLevelValue", 0.0))
+        self.duty_cycle_pulse_width = parameters.get("DutyCyclePulseWidth", "Duty cycle in %")
+        self.duty_cycle_pulse_width_value = float(parameters.get("DutyCyclePulseWidthValue", 50))
+        self.delay_phase = parameters.get("DelayPhase", "Phase in deg")
+        self.delay_phase_value = float(parameters.get("DelayPhaseValue", 0))
+        self.impedance = parameters.get("Impedance", "High-Z")
+
         index_to_split_unit = self.sweep_mode.rfind(" ")
-        
-        self.variables = [self.sweep_mode[:index_to_split_unit]]
-        
-        self.shortname = '33600A CH' + self.channel
-        
-        # must be part of the MeasClass
-        if self.sweep_mode == 'Frequency [Hz]':
-            self.units =    ['Hz']
-        elif self.sweep_mode == 'Period [s]':
-            self.units =    ['s']    
-        elif self.sweep_mode == 'DutyCycle [%]':
-            self.units =    ['%']
-        elif self.sweep_mode == 'None':
-            self.variables =[]
-            self.units =    []
-            self.plottype = []     # True to plot data
-            self.savetype = []     # True to save data
-        else:
-            self.units =    ['V']
 
-    def initialize(self):
-    
-        pass   
-        #self.port.write("*IDN?")
-        #print(self.port.read())
-        
-        # self.port.write("*RST")
-        
-    def configure(self):
-        
+        self.variables = [self.sweep_mode[:index_to_split_unit]]
+
+        self.shortname = "33600A CH" + self.channel
+
+        # must be part of the MeasClass
+        if self.sweep_mode == "Frequency in Hz":
+            self.units = ["Hz"]
+        elif self.sweep_mode == "Period in s":
+            self.units = ["s"]
+        elif self.sweep_mode == "DutyCycle in %":
+            self.units = ["%"]
+        elif self.sweep_mode == "None":
+            self.variables = []
+            self.units = []
+            self.plottype = []  # True to plot data
+            self.savetype = []  # True to save data
+        else:
+            self.units = ["V"]
+
+    def configure(self) -> None:
+        """Configure the device. This function is called every time the device is used in the sequencer."""
         if self.impedance == "High-Z":
             self.port.write("OUTP%s:LOAD INF" % (self.channel))
         if self.impedance == "50 Ohm":
             self.port.write("OUTP%s:LOAD 50" % (self.channel))
-        
+
         # Autoranging the voltage port
         self.port.write("SOUR%s:VOLT:RANG:AUTO ON" % self.channel)
 
-        
-        
-        # if self.sweep_mode == "DelayPhase": 
-            # self.delayphase = self.value 
+        # if self.sweep_mode == "DelayPhase":
+        # self.delayphase = self.value
 
-        if self.periodfrequency == "Period [s]":
-            self.frequency = 1.0/self.periodfrequencyvalue
+        if self.period_frequency == "Period in s":
+            self.frequency = 1.0 / self.period_frequency_value
         else:
-            self.frequency = self.periodfrequencyvalue
-            
-            
-        if self.amplitudehilevel == "Amplitude [V]":
-            self.amplitude = self.amplitudehilevelvalue
-            
-            if self.offsetlolevel == "Offset [V]":
-                self.offset = self.offsetlolevelvalue
+            self.frequency = self.period_frequency_value
+
+        if self.amplitude_hi_level == "Amplitude in V":
+            self.amplitude = self.amplitude_hi_level_value
+
+            if self.offset_lo_level == "Offset in V":
+                self.offset = self.offset_lo_level_value
             else:
-                self.offset = (self.amplitudehilevelvalue/2.0 + self.offsetlolevelvalue)
-              
+                self.offset = (self.amplitude_hi_level_value / 2.0 + self.offset_lo_level_value)
+
         else:
-            if self.offsetlolevel == "Offset [V]":
-                self.amplitude = (self.amplitudehilevelvalue - self.offsetlolevelvalue)*2.0
-                self.offset = self.offsetlolevelvalue
+            if self.offset_lo_level == "Offset in V":
+                self.amplitude = (self.amplitude_hi_level_value - self.offset_lo_level_value) * 2.0
+                self.offset = self.offset_lo_level_value
             else:
-                self.amplitude = self.amplitudehilevelvalue - self.offsetlolevelvalue
-                self.offset = (self.amplitudehilevelvalue - self.offsetlolevelvalue)/2.0
-                
+                self.amplitude = self.amplitude_hi_level_value - self.offset_lo_level_value
+                self.offset = (self.amplitude_hi_level_value - self.offset_lo_level_value) / 2.0
 
         ### Get Arbitrary Waveform ###
-        
+
         if self.waveform.startswith("Arbitrary:") or self.waveform not in self.waveform_standard_list:
-        
-            # we strip off all file extensions and whitespaces and also the leading 'Arbitrary:" if it has been used
+
+            # we strip off all file extensions and whitespaces and also the leading "Arbitrary:" if it has been used
             # further we only use uppercase as the device as anyway just knows uppercase file names 
-            waveform_command = self.waveform.replace("Arbitrary:","").strip().replace(".ARB","").replace(".arb","").replace(".Arb","").upper() 
-            
+            waveform_command = self.waveform.replace("Arbitrary:", "").strip().replace(".ARB", "").replace(".arb",
+                                                                                                           "").replace(
+                ".Arb", "").upper()
+
             self.port.write("SOUR%s:FUNC ARB" % (self.channel))
             self.port.write("FUNC:USER %s" % (waveform_command))
 
@@ -196,183 +203,163 @@ class Device(EmptyDevice):
             self.port.write("FUNC:USER?")
             answer = self.port.read()
 
-            #print(answer,waveform_command)
-
             if answer != waveform_command:
-                self.stop_Measurement("Cannot find the selected user function %s (check spelling/uppercases) " % waveform_command)
+                self.stop_Measurement(
+                    "Cannot find the selected user function %s (check spelling/uppercases) " % waveform_command)
                 return False
-                
+
             waveform_type = "USER"
-        
+
         else:
-            
+
             waveform_type = self.commands[self.waveform]
-            
 
-        self.port.write("SOUR%s:APPL:%s %s, %s, %s" % (self.channel, waveform_type, self.frequency, self.amplitude, self.offset))
-            
-        
-        
+        self.port.write(
+            "SOUR%s:APPL:%s %s, %s, %s" % (self.channel, waveform_type, self.frequency, self.amplitude, self.offset))
+
         if self.waveform == "Pulse":
-            if self.dutycyclepulsewidth ==  "Pulse width [s]":
-                self.port.write("SOUR%s:FUNC:PULS:WIDT %s " % (self.channel ,self.dutycyclepulsewidthvalue))
-                
-            if self.dutycyclepulsewidth ==  "Duty cycle [%]":
-                self.port.write("SOUR%s:FUNC:PULS:DCYC %s " % (self.channel ,self.dutycyclepulsewidthvalue))
-                
-        elif self.waveform == "Square":
-            if self.dutycyclepulsewidth ==  "Duty cycle [%]":
-                self.port.write("SOUR%s:FUNC:SQU:DCYC %s " % (self.channel ,self.dutycyclepulsewidthvalue))
-                
-                
-        if self.delayphase ==  "Delay [s]": 
-            self.phase = self.delayphasevalue * self.frequency * 360.0
+            if self.duty_cycle_pulse_width == "Pulse width in s":
+                self.port.write("SOUR%s:FUNC:PULS:WIDT %s " % (self.channel, self.duty_cycle_pulse_width_value))
 
-                    
-        elif self.delayphase ==  "Phase [deg]":
-            self.phase = self.delayphasevalue
-            
-        
-        if not waveform_type == "DC":
+            if self.duty_cycle_pulse_width == "Duty cycle in %":
+                self.port.write("SOUR%s:FUNC:PULS:DCYC %s " % (self.channel, self.duty_cycle_pulse_width_value))
+
+        elif self.waveform == "Square":
+            if self.duty_cycle_pulse_width == "Duty cycle in %":
+                self.port.write("SOUR%s:FUNC:SQU:DCYC %s " % (self.channel, self.duty_cycle_pulse_width_value))
+
+        if self.delay_phase == "Delay in s":
+            self.phase = self.delay_phase_value * self.frequency * 360.0
+
+
+        elif self.delay_phase == "Phase in deg":
+            self.phase = self.delay_phase_value
+
+        if waveform_type != "DC":
             self.port.write("SOUR%s:PHAS %s DEG" % (self.channel, self.phase))
 
-                                  
-    def deinitialize(self):
-        pass
-        # self.port.write("*RST")
-        # self.port.write("SYST:LOC")
-         
-    def poweron(self):
+    def poweron(self) -> None:
+        """Turn on the device when entering a sequencer branch if it was not already used in the previous branch."""
         self.port.write("OUTP%s ON" % self.channel)
-        
-    def poweroff(self):
+
+    def poweroff(self) -> None:
+        """Turn off the device when leaving a sequencer branch."""
         self.port.write("OUTP%s OFF" % self.channel)
-        
+
         # we have to ask to really switch off and we do not know why
         self.port.write("OUTP?")
         answer = self.port.read()
-        #print(answer)
-                                 
-    def apply(self):
-    
-        if self.sweep_mode == 'None':
-            pass
-            
+        # print(answer)
+
+    def apply(self) -> None:
+        """'apply' is used to set the new set value that is always available as 'self.value'."""
+        if self.sweep_mode == "None":
+            return
+
+        if self.sweep_mode == "Frequency in Hz":
+            self.period_frequency = "Frequency in Hz"
+            self.period_frequency_value = self.value
+
+        if self.sweep_mode == "Period in s":
+            self.period_frequency = "Frequency in Hz"
+            self.period_frequency_value = 1.0 / self.value
+
+        if self.sweep_mode == "Amplitude in V":
+            self.amplitude_hi_level = "Amplitude in V"
+            self.amplitude_hi_level_value = self.value
+
+        if self.sweep_mode == "HiLevel in V":
+            self.amplitude_hi_level = "HiLevel in V"
+            self.amplitude_hi_level_value = self.value
+
+        if self.sweep_mode == "Offset in V":
+            self.offset_lo_level = "Offset in V"
+            self.offset_lo_level_value = self.value
+
+        if self.sweep_mode == "LoLevel in V":
+            self.offset_lo_level = "LoLevel in V"
+            self.offset_lo_level_value = self.value
+
+        if self.period_frequency == "Period in s":
+            self.frequency = 1.0 / self.period_frequency_value
         else:
-        
-            if self.sweep_mode == "Frequency [Hz]":
-                self.periodfrequency = "Frequency [Hz]"
-                self.periodfrequencyvalue = self.value
-            
-            if self.sweep_mode == "Period [s]":
-                self.periodfrequency = "Frequency [Hz]"
-                self.periodfrequencyvalue = 1.0/self.value
-                
-            if self.sweep_mode == "Amplitude [V]":  
-                self.amplitudehilevel = "Amplitude [V]"
-                self.amplitudehilevelvalue = self.value
-                
-            if self.sweep_mode == "HiLevel [V]":
-                self.amplitudehilevel = "HiLevel [V]"
-                self.amplitudehilevelvalue = self.value
-                   
-            if self.sweep_mode == "Offset [V]": 
-                self.offsetlolevel = "Offset [V]"
-                self.offsetlolevelvalue = self.value   
+            self.frequency = self.period_frequency_value
 
-            if self.sweep_mode == "LoLevel [V]":
-                self.offsetlolevel = "LoLevel [V]"
-                self.offsetlolevelvalue = self.value        
-        
-            if self.periodfrequency == "Period [s]":
-                self.frequency = 1.0 / self.periodfrequencyvalue
-            else:
-                self.frequency = self.periodfrequencyvalue
-                
-            if self.amplitudehilevel == "Amplitude [V]":
-                self.amplitude = self.amplitudehilevelvalue
-                
-                if self.offsetlolevel == "Offset [V]":
-                    self.offset = self.offsetlolevelvalue
-                else:
-                    self.offset = (self.amplitudehilevelvalue/2.0 + self.offsetlolevelvalue)
-                  
-            else:
-                if self.offsetlolevel == "Offset [V]":
-                    self.amplitude = (self.amplitudehilevelvalue - self.offsetlolevelvalue)*2.0
-                    self.offset = self.offsetlolevelvalue
-                else:
-                    self.amplitude = self.amplitudehilevelvalue - self.offsetlolevelvalue
-                    self.offset = (self.amplitudehilevelvalue + self.offsetlolevelvalue)/2.0
-           
-            
-            self.port.write("SOUR%s:FREQ %s" % (self.channel, self.frequency))  
-            self.port.write("SOUR%s:VOLT %s" % (self.channel, self.amplitude))  
-            self.port.write("SOUR%s:VOLT:OFFS %s" % (self.channel, self.offset))  
-                
-            if self.sweep_mode == "Pulse width [s]":
-                self.dutycyclepulsewidthvalue = self.value
-                
-            if self.sweep_mode == "Duty cycle [%]":
-                self.dutycyclepulsewidthvalue = self.value
-                
-            if self.waveform == "Pulse":
-                if self.dutycyclepulsewidth ==  "Pulse width [s]":
-                    self.port.write("SOUR%s:FUNC:PULS:WIDT %s " % (self.channel, self.dutycyclepulsewidthvalue))
-                    
-                if self.dutycyclepulsewidth ==  "Duty cycle [%]":
-                    self.port.write("SOUR%s:FUNC:PULS:DCYC %s " % (self.channel, self.dutycyclepulsewidthvalue))
-                 
-                 
-            if self.sweep_mode == "Delay [s]": 
-                self.phase = self.value * self.frequency * 360.0
-                self.port.write("SOUR%s:PHAS %s DEG " % (self.channel, self.phase))
-                
-            if self.sweep_mode == "Phase [deg]":
-                self.phase = self.value
-                self.port.write("SOUR%s:PHAS %s DEG " % (self.channel, self.phase))
-            
-            
-    def measure(self):
+        if self.amplitude_hi_level == "Amplitude in V":
+            self.amplitude = self.amplitude_hi_level_value
 
-        if self.sweep_mode != 'None':
-            self.port.write("SOUR%s:APPL?" % (self.channel))
-            
-    
-    def call(self):
-        
-        if self.sweep_mode == 'None':
-            return []
+            if self.offset_lo_level == "Offset in V":
+                self.offset = self.offset_lo_level_value
+            else:
+                self.offset = (self.amplitude_hi_level_value / 2.0 + self.offset_lo_level_value)
+
         else:
-        
-            answer = self.port.read().replace("\"", "").split(" ")[1].split(",")
-            
-            frequency, amplitude, offset = map(float, answer)
-            
-            if self.sweep_mode == "Frequency [Hz]":
-                returnvalue = frequency
-            
-            if self.sweep_mode == "Period [s]":
-                returnvalue = 1.0/frequency
-                
-            if self.sweep_mode == "Amplitude [V]":  
-                returnvalue = amplitude
-                
-            if self.sweep_mode == "HiLevel [V]":
-                returnvalue = offset + amplitude/2.0
-                   
-            if self.sweep_mode == "Offset [V]": 
-                returnvalue = offset
+            if self.offset_lo_level == "Offset in V":
+                self.amplitude = (self.amplitude_hi_level_value - self.offset_lo_level_value) * 2.0
+                self.offset = self.offset_lo_level_value
+            else:
+                self.amplitude = self.amplitude_hi_level_value - self.offset_lo_level_value
+                self.offset = (self.amplitude_hi_level_value + self.offset_lo_level_value) / 2.0
 
-            if self.sweep_mode == "LoLevel [V]":
-                returnvalue = offset - amplitude/2.0
-                
-            if self.sweep_mode == "Duty cycle [%]" or self.sweep_mode == "Pulse width [s]":
-                returnvalue = self.value
-                
-            if self.sweep_mode == "Delay [s]" or self.sweep_mode == "Phase [deg]":
-                returnvalue = self.value
+        self.port.write("SOUR%s:FREQ %s" % (self.channel, self.frequency))
+        self.port.write("SOUR%s:VOLT %s" % (self.channel, self.amplitude))
+        self.port.write("SOUR%s:VOLT:OFFS %s" % (self.channel, self.offset))
 
-            return [returnvalue]
-        
-                    
+        if self.sweep_mode == "Pulse width in s":
+            self.duty_cycle_pulse_width_value = self.value
+
+        if self.sweep_mode == "Duty cycle in %":
+            self.duty_cycle_pulse_width_value = self.value
+
+        if self.waveform == "Pulse":
+            if self.duty_cycle_pulse_width == "Pulse width in s":
+                self.port.write("SOUR%s:FUNC:PULS:WIDT %s " % (self.channel, self.duty_cycle_pulse_width_value))
+
+            if self.duty_cycle_pulse_width == "Duty cycle in %":
+                self.port.write("SOUR%s:FUNC:PULS:DCYC %s " % (self.channel, self.duty_cycle_pulse_width_value))
+
+        if self.sweep_mode == "Delay in s":
+            self.phase = self.value * self.frequency * 360.0
+            self.port.write("SOUR%s:PHAS %s DEG " % (self.channel, self.phase))
+
+        if self.sweep_mode == "Phase in deg":
+            self.phase = self.value
+            self.port.write("SOUR%s:PHAS %s DEG " % (self.channel, self.phase))
+
+    def call(self) -> float | None:
+        """Return the measurement results. Must return as many values as defined in self.variables."""
+        if self.sweep_mode == "None":
+            return None
+
+        self.port.write("SOUR%s:APPL?" % (self.channel))
+        answer = self.port.read().replace("\"", "").split(" ")[1].split(",")
+
+        frequency, amplitude, offset = map(float, answer)
+
+        if self.sweep_mode == "Frequency in Hz":
+            return frequency
+
+        elif self.sweep_mode == "Period in s":
+            return 1.0 / frequency
+
+        elif self.sweep_mode == "Amplitude in V":
+            return amplitude
+
+        elif self.sweep_mode == "HiLevel in V":
+            return offset + amplitude / 2.0
+
+        elif self.sweep_mode == "Offset in V":
+            return offset
+
+        elif self.sweep_mode == "LoLevel in V":
+            return offset - amplitude / 2.0
+
+        elif self.sweep_mode == "Duty cycle in %" or self.sweep_mode == "Pulse width in s":
+            return float(self.value)
+
+        elif self.sweep_mode == "Delay in s" or self.sweep_mode == "Phase in deg":
+            return float(self.value)
+
+        else:
+            # Fallback for other sweep modes
+            return float(self.value)

--- a/src/Signal-Agilent_33600A/main.py
+++ b/src/Signal-Agilent_33600A/main.py
@@ -34,8 +34,6 @@ from EmptyDeviceClass import EmptyDevice
 
 class Device(EmptyDevice):
 
-    multichannel = [" CH1", " CH2"]
-
     def __init__(self):
     
         EmptyDevice.__init__(self)
@@ -44,9 +42,6 @@ class Device(EmptyDevice):
         self.port_types = ['USB', 'GPIB']
         self.port_identifications = ['Agilent Technologies,336', 'Agilent Technologies,335']
         
-        # remains here for compatibility with v1.5.3
-        self.multichannel = [" CH1", " CH2"]
-
         # to be defined by user
         self.commands = {   "Sine":"SIN",
                             "Square":"SQU", 
@@ -83,6 +78,7 @@ class Device(EmptyDevice):
     def set_GUIparameter(self):
         GUIparameter = {
                         "SweepMode": ["Frequency [Hz]", "Period [s]", "Amplitude [V]", "HiLevel [V]", "Offset [V]", "LoLevel [V]", "Pulse width [s]", "Duty cycle [%]", "Delay [s]", "Phase [deg]", "None"],
+                        "Channel": ["CH1", "CH2"],
                         "PeriodFrequency" : ["Frequency [Hz]", "Period [s]"],
                         "PeriodFrequencyValue": 1000,
                         "AmplitudeHiLevel" : ["Amplitude [V]", "HiLevel [V]"],
@@ -102,7 +98,7 @@ class Device(EmptyDevice):
         
     def get_GUIparameter(self, parameter={}):
         # could be part of the MeasClass
-        self.channel                  = parameter['Device'][-1]
+        self.channel                  = parameter['Channel'][-1]
         self.sweep_mode               = parameter['SweepMode'] 
         self.waveform                 = parameter['Waveform'] 
         self.periodfrequency          = parameter['PeriodFrequency' ]
@@ -138,9 +134,7 @@ class Device(EmptyDevice):
             self.savetype = []     # True to save data
         else:
             self.units =    ['V']
-        
 
-        
     def initialize(self):
     
         pass   

--- a/src/Signal-AimTTi_TGP3122/license.txt
+++ b/src/Signal-AimTTi_TGP3122/license.txt
@@ -5,7 +5,7 @@ find those in the corresponding folders or contact the maintainer.
 
 MIT License
 
-Copyright (c) 2018 Axel Fischer (sweep-me.net)
+Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Signal-AimTTi_TGP3122/main.py
+++ b/src/Signal-AimTTi_TGP3122/main.py
@@ -35,8 +35,6 @@ from EmptyDeviceClass import EmptyDevice
 
 class Device(EmptyDevice):
 
-    multichannel = [" CH1", " CH2"]
-
     def __init__(self):
     
     
@@ -55,9 +53,6 @@ class Device(EmptyDevice):
                                 }
         #self.port_identifications = ['']
         
-        # remains here for compatibility with v1.5.3
-        self.multichannel = [" CH1", " CH2"]
-
         # to be defined by user
         self.commands = {  
                             "Period [s]":"PER", 
@@ -89,6 +84,7 @@ class Device(EmptyDevice):
     
         GUIparameter = {
                         "SweepMode" : ["Frequency [Hz]", "Period [s]", "Amplitude [V]", "Offset [V]", "HiLevel [V]", "LoLevel [V]", "Phase [deg]", "Delay [s]", "None"],
+                        "Channel": [" CH1", " CH2"],
                         "Waveform": list(self.waveforms.keys()),
                         "PeriodFrequency" : ["Period [s]", "Frequency [Hz]"],
                         "AmplitudeHiLevel" : ["Amplitude [V]", "HiLevel [V]"],
@@ -109,7 +105,7 @@ class Device(EmptyDevice):
         self.device = parameter['Device']
     
         self.shortname = 'TGP3122' + self.device[-4:]
-        self.channel = int(self.device[-1])
+        self.channel = int(parameter["Channel"][-1])
         
         # could be part of the MeasClass
         self.sweep_mode                 = parameter['SweepMode'] 

--- a/src/Signal-AimTTi_TGP3122/main.py
+++ b/src/Signal-AimTTi_TGP3122/main.py
@@ -5,7 +5,7 @@
 #
 # MIT License
 # 
-# Copyright (c) 2018 Axel Fischer (sweep-me.net)
+# Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,188 +25,182 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# SweepMe! device class
-# Type: Signal
-# Device: AIM-TTi TGP3122
+# SweepMe! driver
+# * Module: Signal
+# * Instrument: AIM-TTi TGP3122
 
 from collections import OrderedDict
+from typing import Any
 
-from EmptyDeviceClass import EmptyDevice
+from pysweepme.EmptyDeviceClass import EmptyDevice
+
 
 class Device(EmptyDevice):
 
     def __init__(self):
-    
-    
+
         EmptyDevice.__init__(self)
-        
+
         self.idlevalue = None
-        
+
         self.port_manager = True
-        self.port_types = ['COM']
-        
+        self.port_types = ["COM"]
+
         self.port_properties = {
-                                "EOL": "\n",
-                                "Baudrate": 9600,
-                                "timeout":1,
-                                #"query": "*IDN?",
-                                }
-        #self.port_identifications = ['']
-        
+            "EOL": "\n",
+            "Baudrate": 9600,
+            "timeout": 1,
+            # "query": "*IDN?",
+        }
+        # self.port_identifications = [""]
+
         # to be defined by user
-        self.commands = {  
-                            "Period [s]":"PER", 
-                            "Frequency [Hz]":"FREQ", 
-                            "HiLevel [V]":"HILVL", 
-                            "LoLevel [V]":"LOLVL",
-                            "Amplitude [V]":"AMPL",
-                            "Offset [V]":"DCOFFS",
-                            "Phase [deg]":"PHASE",
-                            "Delay [s]": "PHASE",
-                        }
-                        
+        self.commands = {
+            "Period in s": "PER",
+            "Frequency in Hz": "FREQ",
+            "HiLevel in V": "HILVL",
+            "LoLevel in V": "LOLVL",
+            "Amplitude in V": "AMPL",
+            "Offset in V": "DCOFFS",
+            "Phase in deg": "PHASE",
+            "Delay in s": "PHASE",
+        }
+
         self.waveforms = OrderedDict([
-                           ("Sine", "SINE"),
-                           ("Square", "SQUARE"), 
-                           ("Ramp", "RAMP"), 
-                           ("Pulse", "PULSE"), 
-                           ("Doublepulse", "DOUBLEPULSE"),
-                           ("Noise", "NOISE"),
-                           ("Arb", "ARB"),
-                           ("Triangle", "TRIANG")
-                        ])
-        
-        self.plottype = [True] # True to plot data
-        self.savetype = [True] # True to save data
-        
-               
-    def set_GUIparameter(self):
-    
-        GUIparameter = {
-                        "SweepMode" : ["Frequency [Hz]", "Period [s]", "Amplitude [V]", "Offset [V]", "HiLevel [V]", "LoLevel [V]", "Phase [deg]", "Delay [s]", "None"],
-                        "Channel": [" CH1", " CH2"],
-                        "Waveform": list(self.waveforms.keys()),
-                        "PeriodFrequency" : ["Period [s]", "Frequency [Hz]"],
-                        "AmplitudeHiLevel" : ["Amplitude [V]", "HiLevel [V]"],
-                        "OffsetLoLevel" : ["Offset [V]", "LoLevel [V]"],
-                        "DelayPhase": ["Phase [deg]", "Delay [s]"],
-                        #"DutyCyclePulseWidth": ["Duty cycle [%]"],
-                        "PeriodFrequencyValue": 1000,
-                        "AmplitudeHiLevelValue": 1.0,
-                        "OffsetLoLevelValue": 0.0,
-                        "DelayPhaseValue": 0,
-                        #"DutyCyclePulseWidthValue": 50,
-                        }
-                        
-        return GUIparameter
-                
-    def get_GUIparameter(self, parameter={}):
-    
-        self.device = parameter['Device']
-    
-        self.shortname = 'TGP3122' + self.device[-4:]
-        self.channel = int(parameter["Channel"][-1])
-        
+            ("Sine", "SINE"),
+            ("Square", "SQUARE"),
+            ("Ramp", "RAMP"),
+            ("Pulse", "PULSE"),
+            ("Doublepulse", "DOUBLEPULSE"),
+            ("Noise", "NOISE"),
+            ("Arb", "ARB"),
+            ("Triangle", "TRIANG")
+        ])
+
+        # Measurement Parameters
+        self.sweep_mode: str = "None"
+        self.channel: int = 1
+        self.waveform: str = "Sine"
+        self.period_frequency: str = "Frequency in Hz"
+        self.period_frequency_value: float = 1000
+        self.amplitude_hi_level: str = "Amplitude in V"
+        self.amplitude_hi_level_value: float = 1.0
+        self.offset_lo_level: str = "Offset in V"
+        self.offset_lo_level_value: float = 0.0
+        self.duty_cycle_pulse_width: str = "Duty cycle in %"
+        self.duty_cycle_pulse_width_value: float = 50
+        self.delay_phase: str = "Phase in deg"
+        self.delay_phase_value: float = 0
+
+        self.plottype = [True]  # True to plot data
+        self.savetype = [True]  # True to save data
+
+    def update_gui_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Returns a dictionary with keys and values to generate GUI elements in the SweepMe! GUI."""
+        return {
+            "SweepMode": ["Frequency in Hz", "Period in s", "Amplitude in V", "Offset in V", "HiLevel in V",
+                          "LoLevel in V", "Phase in deg", "Delay in s", "None"],
+            "Channel": ["1", "2"],
+            "Waveform": list(self.waveforms.keys()),
+            "PeriodFrequency": ["Period in s", "Frequency in Hz"],
+            "AmplitudeHiLevel": ["Amplitude in V", "HiLevel in V"],
+            "OffsetLoLevel": ["Offset in V", "LoLevel in V"],
+            "DelayPhase": ["Phase in deg", "Delay in s"],
+            # "DutyCyclePulseWidth": ["Duty cycle in %"],
+            "PeriodFrequencyValue": 1000,
+            "AmplitudeHiLevelValue": 1.0,
+            "OffsetLoLevelValue": 0.0,
+            "DelayPhaseValue": 0,
+            # "DutyCyclePulseWidthValue": 50,
+        }
+
+    def apply_gui_parameters(self, parameters: dict[str, Any]) -> None:
+        """Receive the values of the GUI parameters that were set by the user in the SweepMe! GUI."""
+        self.device = parameters.get("Device", "")  # e.g. "COM3"
+        self.shortname = "TGP3122" + self.device[-4:]
+        self.channel = int(parameters.get("Channel", "1")[-1])
+
         # could be part of the MeasClass
-        self.sweep_mode                 = parameter['SweepMode'] 
-        self.waveform                   = parameter['Waveform'] 
-        self.periodfrequency            = parameter['PeriodFrequency' ]
-        self.periodfrequencyvalue       = parameter['PeriodFrequencyValue']
-        self.amplitudehilevel           = parameter['AmplitudeHiLevel']
-        self.amplitudehilevelvalue      = parameter['AmplitudeHiLevelValue']
-        self.offsetlolevel              = parameter['OffsetLoLevel']
-        self.offsetlolevelvalue         = parameter['OffsetLoLevelValue']
-        self.dutycyclepulsewidth        = parameter['DutyCyclePulseWidth']
-        self.dutycyclepulsewidthvalue   = parameter['DutyCyclePulseWidthValue']
-        self.delayphase                 = parameter['DelayPhase']
-        self.delayphasevalue            = parameter['DelayPhaseValue']
-        
-        
+        self.sweep_mode = parameters.get("SweepMode", "None")
+        self.waveform = parameters.get("Waveform", "Sine")
+        self.period_frequency = parameters.get("PeriodFrequency", "Frequency in Hz")
+        self.period_frequency_value = parameters.get("PeriodFrequencyValue", 1000)
+        self.amplitude_hi_level = parameters.get("AmplitudeHiLevel", "Amplitude in V")
+        self.amplitude_hi_level_value = parameters.get("AmplitudeHiLevelValue", 1.0)
+        self.offset_lo_level = parameters.get("OffsetLoLevel", "Offset in V")
+        self.offset_lo_level_value = parameters.get("OffsetLoLevelValue", 0.0)
+        self.duty_cycle_pulse_width = parameters.get("DutyCyclePulseWidth", "Duty cycle in %")
+        self.duty_cycle_pulse_width_value = parameters.get("DutyCyclePulseWidthValue", 50)
+        self.delay_phase = parameters.get("DelayPhase", "Phase in deg")
+        self.delay_phase_value = parameters.get("DelayPhaseValue", 0)
+
         if self.sweep_mode == "None":
             self.variables = []
-            self.units     = []
-            self.plottype  = []     # True to plot data
-            self.savetype  = []          # True to save data
-            
+            self.units = []
+            self.plottype = []  # True to plot data
+            self.savetype = []  # True to save data
+
         else:
             self.variables = [self.sweep_mode.split(" ")[0]]
             self.units = [self.sweep_mode.split(" ")[1][1:-1]]
 
-      
-    def initialize(self):
-        # self.port.write("BEEPMODE ON")
-    
-        # self.port.write("BEEP")
-        
+    def initialize(self) -> None:
+        """Initialize the device, e.g. set the initial state of the device."""
         self.port.write("BEEPMODE OFF")
-    
+
         self.port.write("CHN %i" % self.channel)
 
-        self.port.write("WAVE %s" % self.waveforms[self.waveform])   
+        self.port.write("WAVE %s" % self.waveforms[self.waveform])
 
-        self.port.write("ALIGN") # aligns the two channel to the same phase 
+        self.port.write("ALIGN")  # aligns the two channel to the same phase
 
-        
         # set period/frequency
-        self.port.write("%s %s" % (self.commands[self.periodfrequency ], self.periodfrequencyvalue))    
-        self.port.write("%s %s" % (self.commands[self.amplitudehilevel], self.amplitudehilevelvalue))  
-        self.port.write("%s %s" % (self.commands[self.offsetlolevel], self.offsetlolevelvalue)) 
-        
-        if self.delayphase == "Delay [s]":
-            if self.periodfrequency == "Period [s]":
-                self.delayphasevalue = 360.0 * float(self.delayphasevalue) / float(self.periodfrequencyvalue)
+        self.port.write("%s %s" % (self.commands[self.period_frequency], self.period_frequency_value))
+        self.port.write("%s %s" % (self.commands[self.amplitude_hi_level], self.amplitude_hi_level_value))
+        self.port.write("%s %s" % (self.commands[self.offset_lo_level], self.offset_lo_level_value))
+
+        if self.delay_phase == "Delay in s":
+            if self.period_frequency == "Period in s":
+                self.delay_phase_value = 360.0 * float(self.delay_phase_value) / float(self.period_frequency_value)
             else:
-                self.delayphasevalue = 360.0 * float(self.delayphasevalue) * float(self.periodfrequencyvalue)
-                
-            
-        self.port.write("%s %s" % (self.commands[self.delayphase], self.delayphasevalue))   
-               
-        
+                self.delay_phase_value = 360.0 * float(self.delay_phase_value) * float(self.period_frequency_value)
+
+        self.port.write("%s %s" % (self.commands[self.delay_phase], self.delay_phase_value))
+
         # VOLT 3.0 Set amplitude to 3 Vpp
         # VOLT:OFFS -2.5 Set offset to -2.5 Vdc
-                        
-    def deinitialize(self):
-        pass
-        # self.port.write("BEEPMODE ON")
-    
-        # self.port.write("BEEP")
-        
-        # self.port.write("BEEPMODE OFF")
-        #self.port.write("*RST")
-        # self.port.write("SYST:LOC")
-         
-    def poweron(self):
+
+    def poweron(self) -> None:
+        """Turn on the output and activate the channel."""
         self.port.write("CHN %i" % self.channel)
         self.port.write("OUTPUT ON")
-        
-    def poweroff(self):
+
+    def poweroff(self) -> None:
+        """Turn off the output and deactivate the channel."""
         self.port.write("CHN %i" % self.channel)
         self.port.write("OUTPUT OFF")
-                        
-    def apply(self):
-        
-        if self.sweep_mode != 'None':
-            self.port.write("CHN %i" % self.channel)
-            if self.sweep_mode == "Delay [s]":
-                if self.periodfrequency == "Period [s]":
-                
-                    self.phasevalue = 360.0 * self.value / float(self.periodfrequencyvalue)
-                else:
-                    self.phasevalue = 360.0 * self.value * float(self.periodfrequencyvalue)
-                
-                self.port.write("%s %s" % (self.commands[self.sweep_mode],self.phasevalue))
-                    
+
+    def apply(self) -> None:
+        """Apply the sweep value."""
+        if self.sweep_mode == "None":
+            return
+
+        self.port.write("CHN %i" % self.channel)
+        if self.sweep_mode == "Delay in s":
+            if self.period_frequency == "Period in s":
+
+                self.phasevalue = 360.0 * self.value / float(self.period_frequency_value)
             else:
-                self.port.write("%s %s" % (self.commands[self.sweep_mode],self.value))
-            
-            
-    def measure(self):
-        pass
-       
-    def call(self):
-        if self.sweep_mode != "None":
-            return [self.value]
+                self.phasevalue = 360.0 * self.value * float(self.period_frequency_value)
+
+            self.port.write("%s %s" % (self.commands[self.sweep_mode], self.phasevalue))
+
         else:
+            self.port.write("%s %s" % (self.commands[self.sweep_mode], self.value))
+
+    def call(self) -> list[float]:
+        """Return the current sweep value as a 1-element list."""
+        if self.sweep_mode != "None":
             return []
-        
-                    
+
+        return [float(self.value)]

--- a/src/Signal-Keysight_N6705/license.txt
+++ b/src/Signal-Keysight_N6705/license.txt
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Gennaro Tortone (Istituto Nazionale di Fisica Nucleare - Sezione di Napoli - tortone@na.infn.it)
+Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Signal-Keysight_N6705/main.py
+++ b/src/Signal-Keysight_N6705/main.py
@@ -6,6 +6,7 @@
 # MIT License
 #
 # Copyright (c) 2022 Gennaro Tortone (Istituto Nazionale di Fisica Nucleare - Sezione di Napoli - tortone@na.infn.it)
+# Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,17 +26,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# SweepMe! device class
-# Type: Signal
-# Device: Keysight N6705
+# SweepMe! driver
+# * Module: Signal
+# * Instrument: Keysight N6705
 
-from EmptyDeviceClass import EmptyDevice
-from ErrorMessage import debug
+from typing import Any
+
+from pysweepme.EmptyDeviceClass import EmptyDevice
+from pysweepme.ErrorMessage import debug
 
 
 class Device(EmptyDevice):
-
-    description =   """
+    description = """
                         Keysight N6705
                         DC power analyzer
                     """
@@ -66,7 +68,7 @@ class Device(EmptyDevice):
         self.NSTEPS = "Number of steps"
         self.TCONSTANT = "Time constant"
         #
-        self.ENDTIME = "End time in s"          # not available on GUI
+        self.ENDTIME = "End time in s"  # not available on GUI
 
         self.waveforms = dict()
         # Sine
@@ -125,10 +127,31 @@ class Device(EmptyDevice):
         self.waveforms['Exponential'][self.TCONSTANT] = dict({"command": "TCONSTANT", "unit": "s"})
         self.waveforms['Exponential'][self.HILEVEL] = dict({"command": "END:LEVEL", "unit": "V"})
 
-    def set_GUIparameter(self):
-        GUIparameter = {
-            "SweepMode": [self.PERIOD, self.FREQUENCY, self.AMPLITUDE, self.HILEVEL, self.OFFSET,  self.LOLEVEL, self.PHASE, \
-                self.DELAY, self.DUTYCYCLE, self.PULSEWIDTH, self.RISETIME, self.FALLTIME, self.NSTEPS,  self.TCONSTANT, "None"],
+        # Measurement Parameters
+        self.channel: str = "1"
+        self.parameters: dict[str, Any] = dict()
+        self.sweep_mode: str = "None"
+        self.waveform: str = "Sine"
+        self.period_frequency: str = self.PERIOD
+        self.period_frequency_value: float = 1.0
+        self.amplitude_hi_level: str = self.AMPLITUDE
+        self.amplitude_hi_level_value: float = 1.0
+        self.offset_lo_level: str = self.OFFSET
+        self.offset_lo_level_value: float = 0.0
+        self.delay_phase: str = self.DELAY
+        self.delay_phase_value: float = 0.0
+        self.duty_cycle_pulse_width: str = self.DUTYCYCLE
+        self.duty_cycle_pulse_width_value: float = 0.0
+        self.rise_time: float = 1.0
+        self.fall_time: float = 1.0
+
+    def update_gui_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Returns a dictionary with keys and values to generate GUI elements in the SweepMe! GUI."""
+        return {
+            "SweepMode": [self.PERIOD, self.FREQUENCY, self.AMPLITUDE, self.HILEVEL, self.OFFSET, self.LOLEVEL,
+                          self.PHASE, \
+                          self.DELAY, self.DUTYCYCLE, self.PULSEWIDTH, self.RISETIME, self.FALLTIME, self.NSTEPS,
+                          self.TCONSTANT, "None"],
             "Channel": ["1", "2", "3", "4"],
             "Waveform": list(self.waveforms.keys()),
             "PeriodFrequency": [self.PERIOD, self.FREQUENCY],
@@ -141,47 +164,43 @@ class Device(EmptyDevice):
             "OffsetLoLevelValue": 0.0,
             "DelayPhaseValue": 10,
             "DutyCyclePulseWidthValue": 5,
-            self.RISETIME: 1,
-            self.FALLTIME: 1
+            "RiseTime": 1,
+            "FallTime": 1,
         }
 
-        return GUIparameter
+    def apply_gui_parameters(self, parameters: dict[str, Any]) -> None:
+        """Receive the values of the GUI parameters that were set by the user in the SweepMe! GUI."""
+        self.parameters = parameters
+        self.sweep_mode = parameters.get('SweepMode', "None")
+        self.waveform = parameters.get('Waveform', "Sine")
 
-    def get_GUIparameter(self, parameter={}):
-        self.sweep_mode = parameter['SweepMode'] 
-        self.waveform = parameter['Waveform']
-        
-        self.periodfrequency          = parameter['PeriodFrequency' ]
-        self.periodfrequencyvalue     = float(parameter['PeriodFrequencyValue'])
-        self.amplitudehilevel         = parameter['AmplitudeHiLevel']
-        self.amplitudehilevelvalue    = float(parameter['AmplitudeHiLevelValue'])
-        self.offsetlolevel            = parameter['OffsetLoLevel']
-        self.offsetlolevelvalue       = float(parameter['OffsetLoLevelValue'])
-        self.delayphase               = parameter['DelayPhase']
-        self.delayphasevalue          = float(parameter['DelayPhaseValue'])
-        self.dutycyclepulsewidth      = parameter['DutyCyclePulseWidth']
-        self.dutycyclepulsewidthvalue = float(parameter['DutyCyclePulseWidthValue'])
-        self.risetime                 = float(parameter['RiseTime'])
-        self.falltime                 = float(parameter['FallTime'])
+        self.period_frequency = parameters.get('PeriodFrequency', self.PERIOD)
+        self.period_frequency_value = self.convert_gui_value_to_float('PeriodFrequencyValue', 1)
+        self.amplitude_hi_level = parameters.get('AmplitudeHiLevel', self.AMPLITUDE)
+        self.amplitude_hi_level_value = self.convert_gui_value_to_float('AmplitudeHiLevelValue', 1)
+        self.offset_lo_level = parameters.get('OffsetLoLevel', self.OFFSET)
+        self.offset_lo_level_value = self.convert_gui_value_to_float('OffsetLoLevelValue', 0)
+        self.delay_phase = parameters.get('DelayPhase', self.PHASE)
+        self.delay_phase_value = self.convert_gui_value_to_float('DelayPhaseValue', 0)
+        self.duty_cycle_pulse_width = parameters.get('DutyCyclePulseWidth', self.DUTYCYCLE)
+        self.duty_cycle_pulse_width_value = self.convert_gui_value_to_float('DutyCyclePulseWidthValue', 0)
+        self.rise_time = self.convert_gui_value_to_float('RiseTime', 1)
+        self.fall_time = self.convert_gui_value_to_float('FallTime', 1)
 
-        self.device = parameter['Device']
-        self.channel = parameter['Channel']
+        self.channel = parameters.get('Channel', "1")
         self.shortname = "Keysight N6705 CH" + self.channel
 
         self.variables = ['Voltage in V', 'Current in A']
         self.units = ['V', 'A']
         self.plottype = [True, True]
         self.savetype = [True, True]
-        
-    def initialize(self):
 
-        # once at the beginning of the measurement
+    def initialize(self) -> None:
+        """Reset the device at the start of the measurement."""
         self.port.write("*RST")
 
-    def deinitialize(self):
-        pass
-
-    def poweron(self):
+    def poweron(self) -> None:
+        """Turn on the output."""
         # TODO: include current operation mode
         self.port.write(f"VOLT:MODE ARB, (@{self.channel})")
         self.port.write(f"ARB:FUNC:TYPE VOLT, (@{self.channel})")
@@ -192,18 +211,22 @@ class Device(EmptyDevice):
         self.port.write(f"OUTP ON, (@{self.channel})")
         self.port.write(f"INIT:TRAN (@{self.channel})")
 
-    def poweroff(self):
+    def poweroff(self) -> None:
+        """Turn off the output and abort pending waveform generation."""
         self.port.write(f"OUTP OFF, (@{self.channel})")
         self.port.write(f"ABORT:TRAN (@{self.channel})")
 
     def set_parameter(self, param, value):
         arb_prefix = f"ARB:VOLTAGE:{self.waveforms[self.waveform]['label']}"
         if self.waveforms[self.waveform].get(param, False):
-            self.port.write(f"{arb_prefix}:{self.waveforms[self.waveform][param]['command']} {value}, (@{self.channel}); *WAI")
+            self.port.write(
+                f"{arb_prefix}:{self.waveforms[self.waveform][param]['command']} {value}, (@{self.channel}); *WAI")
             return True
-        else: return False
+        else:
+            return False
 
-    def configure(self):
+    def configure(self) -> None:
+        """Configure the waveform parameters based on the selected waveform and sweep mode."""
         if self.waveform == 'Sine':
             self.set_sine_params()
         elif self.waveform == 'Step':
@@ -218,65 +241,69 @@ class Device(EmptyDevice):
             self.set_trapezoid_params()
         elif self.waveform == 'Exponential':
             self.set_exponential_params()
-            
-    def apply(self):
+
+    def apply(self) -> None:
+        """Update the waveform parameters with the new sweep value."""
         if self.sweep_mode == 'None':
-            pass
-        else:
-            self.update_sweep_params(self.value)
-            self.port.write(f"ABORT:TRAN (@{self.channel}); *WAI")  # wait for pending abort                       
-            self.configure()                                        # reconfigure waveform
-            self.port.write(f"INIT:TRAN (@{self.channel})")
+            return
 
-    def measure(self):
-        # default read voltage and current
-        self.port.write(f"MEAS:VOLT? (@{self.channel})")
-        self.port.write(f"MEAS:CURR? (@{self.channel})")
+        self.update_sweep_params(self.value)
+        self.port.write(f"ABORT:TRAN (@{self.channel}); *WAI")  # wait for pending abort
+        self.configure()  # reconfigure waveform
+        self.port.write(f"INIT:TRAN (@{self.channel})")
 
-    def call(self):
-        retarr = []
-        retarr.append(float(self.port.read()))      # voltage
-        retarr.append(float(self.port.read()))      # current
-        
-        return retarr
+    def call(self) -> list[float]:
+        """Query the measurement values in the same phase to allow multi-channel use."""
+        measured_voltage = float(self.port.query(f"MEAS:VOLT? (@{self.channel})"))
+        measured_current = float(self.port.query(f"MEAS:CURR? (@{self.channel})"))
+
+        return [measured_voltage, measured_current]
 
     # convenience functions
 
+    def convert_gui_value_to_float(self, parameter: str, default: float) -> float:
+        """Helper function to convert GUI parameter values to float, with error handling."""
+        try:
+            value = float(self.parameters.get(parameter, default))
+            return value
+        except ValueError:
+            return default
+
     def update_sweep_params(self, value):
         if self.sweep_mode == self.PERIOD or self.sweep_mode == self.FREQUENCY:
-            self.periodfrequencyvalue = value
+            self.period_frequency_value = value
         elif self.sweep_mode == self.AMPLITUDE or self.sweep_mode == self.HILEVEL:
-            self.amplitudehilevelvalue = value
+            self.amplitude_hi_level_value = value
         elif self.sweep_mode == self.OFFSET or self.sweep_mode == self.LOLEVEL:
-            self.offsetlolevelvalue = value
+            self.offset_lo_level_value = value
         elif self.sweep_mode == self.PHASE or self.sweep_mode == self.DELAY:
-            self.delayphasevalue = value
+            self.delay_phase_value = value
         elif self.sweep_mode == self.DUTYCYCLE or self.sweep_mode == self.PULSEWIDTH:
-            self.dutycyclepulsewidthvalue = value
+            self.duty_cycle_pulse_width_value = value
         elif self.sweep_mode == self.RISETIME:
-            self.risetime = value
+            self.rise_time = value
         elif self.sweep_mode == self.FALLTIME:
-            self.falltime = value
+            self.fall_time = value
         elif self.sweep_mode == self.NSTEPS:
-            None    # fixme
+            None  # fixme
         elif self.sweep_mode == self.TCONSTANT:
-            None    # fixme
+            None  # fixme
 
     # STEP
 
     def get_step_params(self):
-        self.delay = self.delayphasevalue
+        self.delay = self.delay_phase_value
 
         # lolevel and offset have same meaning
-        self.lolevel = self.offsetlolevelvalue
+        self.lolevel = self.offset_lo_level_value
 
-        if self.amplitudehilevel == self.AMPLITUDE:
+        if self.amplitude_hi_level == self.AMPLITUDE:
             # hilevel = amplitude + lolevel
-            self.hilevel = self.amplitudehilevelvalue + self.lolevel
+            self.hilevel = self.amplitude_hi_level_value + self.lolevel
         else:
-            self.hilevel = self.amplitudehilevelvalue
+            self.hilevel = self.amplitude_hi_level_value
 
-        return { self.DELAY: self.delay, self.LOLEVEL: self.lolevel, self.HILEVEL: self.hilevel }
+        return {self.DELAY: self.delay, self.LOLEVEL: self.lolevel, self.HILEVEL: self.hilevel}
 
     def set_step_params(self):
         params = self.get_step_params()
@@ -287,29 +314,30 @@ class Device(EmptyDevice):
     # RAMP
 
     def get_ramp_params(self):
-        if self.periodfrequency == self.PERIOD:
-            self.period = self.periodfrequencyvalue
+        if self.period_frequency == self.PERIOD:
+            self.period = self.period_frequency_value
         else:
-            self.period = float(1/self.periodfrequencyvalue)
+            self.period = float(1 / self.period_frequency_value)
 
-        if self.delayphase == self.DELAY:
-            self.delay = self.delayphasevalue
+        if self.delay_phase == self.DELAY:
+            self.delay = self.delay_phase_value
         else:
             # delay = period * phase / 360
-            self.delay = float(self.period * self.delayphasevalue / 360)
+            self.delay = float(self.period * self.delay_phase_value / 360)
 
         # lolevel and offset have same meaning
-        self.lolevel = self.offsetlolevelvalue
+        self.lolevel = self.offset_lo_level_value
 
-        if self.amplitudehilevel == self.AMPLITUDE:
+        if self.amplitude_hi_level == self.AMPLITUDE:
             # hilevel = amplitude + lolevel
-            self.hilevel = self.amplitudehilevelvalue + self.lolevel
+            self.hilevel = self.amplitude_hi_level_value + self.lolevel
         else:
-            self.hilevel = self.amplitudehilevelvalue
+            self.hilevel = self.amplitude_hi_level_value
 
-        self.endtime = self.period - self.risetime - self.delay
+        self.endtime = self.period - self.rise_time - self.delay
 
-        return { self.DELAY: self.delay, self.RISETIME: self.risetime, self.ENDTIME: self.endtime, self.LOLEVEL: self.lolevel, self.HILEVEL: self.hilevel, self.PERIOD: self.period }
+        return {self.DELAY: self.delay, self.RISETIME: self.rise_time, self.ENDTIME: self.endtime,
+                self.LOLEVEL: self.lolevel, self.HILEVEL: self.hilevel, self.PERIOD: self.period}
 
     def set_ramp_params(self):
         params = self.get_ramp_params()
@@ -323,7 +351,7 @@ class Device(EmptyDevice):
 
     def get_staircase_params(self):
         params = self.get_ramp_params()
-        self.nsteps = self.dutycyclepulsewidthvalue
+        self.nsteps = self.duty_cycle_pulse_width_value
         params.update({self.NSTEPS: self.nsteps})
         return params
 
@@ -335,35 +363,35 @@ class Device(EmptyDevice):
         self.set_parameter(self.LOLEVEL, params[self.LOLEVEL])
         self.set_parameter(self.HILEVEL, params[self.HILEVEL])
         self.set_parameter(self.NSTEPS, params[self.NSTEPS])
-    
+
     # SINE 
 
     def get_sine_params(self):
-        if self.periodfrequency == self.PERIOD:
-            self.frequency = 1 / self.periodfrequencyvalue
+        if self.period_frequency == self.PERIOD:
+            self.frequency = 1 / self.period_frequency_value
         else:
-            self.frequency = self.periodfrequencyvalue
+            self.frequency = self.period_frequency_value
 
-        if self.offsetlolevel == self.OFFSET:
-            self.offset = self.offsetlolevelvalue
-            if self.amplitudehilevel == self.AMPLITUDE:
-                self.amplitude = self.amplitudehilevelvalue
-            else: # self.amplitudehilevel == self.HILEVEL
+        if self.offset_lo_level == self.OFFSET:
+            self.offset = self.offset_lo_level_value
+            if self.amplitude_hi_level == self.AMPLITUDE:
+                self.amplitude = self.amplitude_hi_level_value
+            else:  # self.amplitudehilevel == self.HILEVEL
                 # amplitude = hilevel - offset
-                self.amplitude = self.amplitudehilevelvalue - self.offset
+                self.amplitude = self.amplitude_hi_level_value - self.offset
 
-        else: # self.offsetlolevel == self.LOLEVEL:
-            if self.amplitudehilevel == self.AMPLITUDE:
-                self.amplitude = self.amplitudehilevelvalue
+        else:  # self.offsetlolevel == self.LOLEVEL:
+            if self.amplitude_hi_level == self.AMPLITUDE:
+                self.amplitude = self.amplitude_hi_level_value
                 # offset = lolevel + amplitude
-                self.offset = self.offsetlolevelvalue + self.amplitudehilevelvalue
-            else:   # self.amplitudehilevel == self.HILEVEL
+                self.offset = self.offset_lo_level_value + self.amplitude_hi_level_value
+            else:  # self.amplitudehilevel == self.HILEVEL
                 # amplitude - (hilevel - lolevel) / 2
-                self.amplitude = (self.amplitudehilevelvalue - self.offsetlolevelvalue) / 2
+                self.amplitude = (self.amplitude_hi_level_value - self.offset_lo_level_value) / 2
                 # offset = lolevel + ((hilevel - lolevel) / 2)
-                self.offset = self.offsetlolevelvalue + ((self.amplitudehilevelvalue - self.offsetlolevelvalue) / 2)
+                self.offset = self.offset_lo_level_value + ((self.amplitude_hi_level_value - self.offset_lo_level_value) / 2)
 
-        return { self.FREQUENCY: self.frequency, self.AMPLITUDE: self.amplitude, self.OFFSET: self.offset }
+        return {self.FREQUENCY: self.frequency, self.AMPLITUDE: self.amplitude, self.OFFSET: self.offset}
 
     def set_sine_params(self):
         params = self.get_sine_params()
@@ -378,15 +406,15 @@ class Device(EmptyDevice):
         # remove parameters not used
         params.pop(self.RISETIME)
         params.pop(self.ENDTIME)
-        
-        if self.dutycyclepulsewidth == self.PULSEWIDTH:
-            self.pulsewidth = self.dutycyclepulsewidthvalue
-        elif self.dutycyclepulsewidth == self.DUTYCYCLE:
+
+        if self.duty_cycle_pulse_width == self.PULSEWIDTH:
+            self.pulsewidth = self.duty_cycle_pulse_width_value
+        elif self.duty_cycle_pulse_width == self.DUTYCYCLE:
             # pulsewidth = dutycycle / 100 * period
-            self.pulsewidth = self.dutycyclepulsewidthvalue / 100 * params[self.PERIOD]
-        
+            self.pulsewidth = self.duty_cycle_pulse_width_value / 100 * params[self.PERIOD]
+
         self.endtime = params[self.PERIOD] - self.pulsewidth - params[self.DELAY]
-        
+
         params.update({self.PULSEWIDTH: self.pulsewidth})
         params.update({self.ENDTIME: self.endtime})
 
@@ -405,9 +433,9 @@ class Device(EmptyDevice):
     def get_trapezoid_params(self):
         params = self.get_pulse_params()
 
-        self.endtime = params[self.PERIOD] - self.risetime - params[self.PULSEWIDTH] - self.falltime
-        params.update({self.RISETIME: self.risetime})
-        params.update({self.FALLTIME: self.falltime})
+        self.endtime = params[self.PERIOD] - self.rise_time - params[self.PULSEWIDTH] - self.fall_time
+        params.update({self.RISETIME: self.rise_time})
+        params.update({self.FALLTIME: self.fall_time})
         params.update({self.ENDTIME: self.endtime})
 
         return params
@@ -429,7 +457,7 @@ class Device(EmptyDevice):
         # remove parameters not used
         params.pop(self.ENDTIME)
 
-        self.tconstant = self.dutycyclepulsewidthvalue
+        self.tconstant = self.duty_cycle_pulse_width_value
         params.update({self.TCONSTANT: self.tconstant})
 
         return params


### PR DESCRIPTION
Drivers were using `self.multichannel` (a deprecated pattern) to handle multi-channel operation instead of the standard `Channel` GUI parameter.

## Changes

### `Signal-Agilent_33600A`
- Replace `self.multichannel` with `Channel` GUI parameter reads
- Auto-format and type annotation cleanup
- Update license header

### `Signal-AimTTi_TGP3122`
- Replace `self.multichannel` with `Channel` GUI parameter reads
- Add type annotations
- Update license header

### `Signal-Keysight_N6705`
- Implement channel selection via `Channel` GUI parameter
- Multi-channel measurement readout support
- Add license

### `SMU-Keysight_N6705A`
- Minor GUI parameter handling updates

**Before:**
```python
if self.multichannel:
    self.channel = self.multichannel
```

**After:**
```python
self.channel = self.get_GUIparameter({"Channel": []})[0]
```