### PR TITLE
Simulation drivers

### DIFF
--- a/src/SMU-Simulation_Driver/main.py
+++ b/src/SMU-Simulation_Driver/main.py
@@ -139,15 +139,22 @@ class Device(EmptyDevice):
         self.leakage = parameter.get("Linear Leakage factor", 1.0)
         self.hysteresis = parameter.get("Hysteresis time constant", 0.0)
 
-    def initialize(self) -> None:
-        """Initialize the device. This function is called only once at the start of the measurement."""
+    def configure(self) -> None:
+        """Validate and type-convert the GUI parameters.
+
+        This runs at the start of a measurement and again on every reconfigure()
+        (e.g. when a Control Widget changes a value during a running loop). Doing
+        the conversion here - rather than in initialize(), which is called only
+        once - ensures the values stay correctly typed after each live update,
+        when get_GUIparameter() has re-read them as raw strings.
+        """
+        self.protection = float(self.protection)
         max_compliance = 1.0
-        if float(self.protection) > max_compliance:
+        if self.protection > max_compliance:
             self.stop_Measurement(
                 f"Compliance {self.protection} is higher than the maximum compliance of {max_compliance}."
             )
         self.average = proof_average(self.average)
-        self.protection = float(self.protection)
         self.saturation_current = float(self.saturation_current)
         self.ideality_factor = float(self.ideality_factor)
         self.temperature = float(self.temperature)

--- a/src/SMU-Simulation_Driver/main.py
+++ b/src/SMU-Simulation_Driver/main.py
@@ -157,7 +157,11 @@ class Device(EmptyDevice):
         self.average = proof_average(self.average)
         self.saturation_current = float(self.saturation_current)
         self.ideality_factor = float(self.ideality_factor)
+        if self.ideality_factor <= 0:
+            self.stop_Measurement("Ideality factor must be greater than 0.")
         self.temperature = float(self.temperature)
+        if self.temperature <= 0:
+            self.stop_Measurement("Temperature must be greater than 0 K.")
         self.v_t = self.k * self.temperature / self.q
         self.photocurrent = float(self.photocurrent)
         self.noise = float(self.noise)

--- a/src/Scope-Simulation_Driver/main.py
+++ b/src/Scope-Simulation_Driver/main.py
@@ -125,8 +125,13 @@ class Device(EmptyDevice):
             self.plottype += [True]  # True to plot data
             self.savetype += [True]  # True to save data
 
-    def initialize(self) -> None:
-        """Convert GUI parameters to their destination formats."""
+    def configure(self) -> None:
+        """Configure the device and convert GUI parameters to their destination formats.
+
+        The conversions live here rather than in initialize() so they are redone on
+        every reconfigure() (e.g. a live Control Widget change), where
+        get_GUIparameter() has just re-read these values as raw strings.
+        """
         if self.channel1:
             self.channel1_range = float(self.channel1_range)
             self.channel1_offset = float(self.channel1_offset)
@@ -135,8 +140,6 @@ class Device(EmptyDevice):
             self.channel2_range = float(self.channel2_range)
             self.channel2_offset = float(self.channel2_offset)
 
-    def configure(self) -> None:
-        """Configure the device."""
         # If the Signal-Simulation driver is used in the sequencer, use its signal
         self.use_simulated_signal = "Simulated signal" in self.device_communication
 


### PR DESCRIPTION
Move type conversions of input parameters from initialize() to configure() to avoid TypeErrors when get_GUIparameters() is called without initialize()