### PR TITLE
Lakeshore M81

### DIFF
--- a/src/LockIn-LakeShore_M81-CM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-CM-10/doc/description.md
@@ -1,5 +1,5 @@
 # Lock-In driver for CM-10 module of LakeShore M81:
-- Log current using the VM-10 module of the LakeShore M81 Synchronous Source Measurement System.
+- Log current using the CM-10 module of the LakeShore M81 Synchronous Source Measurement System.
 - Three physical measurement channels (M1, M2 and M3) are available at the M81. Connect your CM-10 module to one of them.
 - Select the corresponding channel number in SweepMe!
 

--- a/src/LockIn-LakeShore_M81-CM-10/main.py
+++ b/src/LockIn-LakeShore_M81-CM-10/main.py
@@ -275,6 +275,15 @@ class Device(EmptyDevice):
         # Bias voltage must be set after filter settings or a warning will appear on the touch panel.
         self.set_bias(self.use_bias, self.bias_voltage)
 
+    def reconfigure(self, parameters=None, keys=None):
+        """Called whenever an element higher up in the sequencer varies its sweep value, i.e. a parameter in the GUI"""
+        if parameters:
+            self.get_GUIparameter(parameters)
+        if self.sweep_mode != "Sensitivity in A":
+            self.set_range()
+        if self.sweep_mode != "Time constant in s":
+            self.set_timeconstant()
+
     """ the following functions are called for each measurement point """
 
     def apply(self):
@@ -492,7 +501,7 @@ class Device(EmptyDevice):
         if self.lia_lowpass:
             if not (10000 >= self.lia_tc >= 0.0001):
                 raise ValueError(
-                    "Lock-In time constant set to {self.lia_tc}. Must be >= 0.0001 s and <= 10,000 s."
+                    f"Lock-In time constant set to {self.lia_tc}. Must be >= 0.0001 s and <= 10,000 s."
                 )
             self.port.write(f"SENSe{self.slot}:LIA:TIMEconstant {self.lia_tc}")
             self.port.write(f"SENSe{self.slot}:LIA:ROLLoff R{self.lia_rolloff}")

--- a/src/LockIn-LakeShore_M81-CM-10/main.py
+++ b/src/LockIn-LakeShore_M81-CM-10/main.py
@@ -268,25 +268,18 @@ class Device(EmptyDevice):
 
     def configure(self):
         self.set_mode()
-        self.set_range()
-        self.set_timeconstant()
+        if self.sweep_mode == "Sensitivity in A":
+            self.set_range()
+        if self.sweep_mode != "Time constant in s":
+            self.set_timeconstant()
         self.set_lockin_settings()
         self.set_advanced_settings()
         # Bias voltage must be set after filter settings or a warning will appear on the touch panel.
         self.set_bias(self.use_bias, self.bias_voltage)
 
-    def reconfigure(self, parameters=None, keys=None):
-        """Called whenever an element higher up in the sequencer varies its sweep value, i.e. a parameter in the GUI"""
-        if parameters:
-            self.get_GUIparameter(parameters)
-        if self.sweep_mode != "Sensitivity in A":
-            self.set_range()
-        if self.sweep_mode != "Time constant in s":
-            self.set_timeconstant()
-
     """ the following functions are called for each measurement point """
 
-    def apply(self):
+    def apply(self) -> None:
         """
         Apply a swept value. Accept both GUI label-strings (e.g. "100 mA")
         and numeric values (strings or numbers). For time constant allow
@@ -426,12 +419,16 @@ class Device(EmptyDevice):
     def set_lockin_settings(self):
         """Wrapper function to set configurations specific to Lock-In Amplifier (LIA) mode."""
         # Reference source
-        if not self.lia_ref in ["S1", "S2", "S3"]:
-            if self.lia_ref.lower().startswith("reference"):
-                self.lia_ref = "RIN"  # External Reference Source
+        # The converted value is kept in a local variable. Overwriting self.lia_ref would
+        # make a second call of this function fail, because "RIN" is neither one of the
+        # source channels nor does it start with "reference".
+        reference = self.lia_ref
+        if not reference in ["S1", "S2", "S3"]:
+            if reference.lower().startswith("reference"):
+                reference = "RIN"  # External Reference Source
             else:
                 raise ValueError(f"No valid reference source selected: {self.lia_ref}.")
-        self.port.write(f"SENSe{self.slot}:LIA:RSOurce {self.lia_ref}")
+        self.port.write(f"SENSe{self.slot}:LIA:RSOurce {reference}")
 
         # Reference harmonic
         try:

--- a/src/LockIn-LakeShore_M81-CM-10/main.py
+++ b/src/LockIn-LakeShore_M81-CM-10/main.py
@@ -335,7 +335,7 @@ class Device(EmptyDevice):
         if self.wait_time:
             start_time = time.time()
             while (
-                not self.is_run_aborted() and time.time() - start_time < self.wait_time
+                not self.is_run_stopped() and time.time() - start_time < self.wait_time
             ):  # this flag is set True when the user presses 'Stop'
                 time.sleep(min(0.1, self.wait_time))
 

--- a/src/LockIn-LakeShore_M81-CM-10/main.py
+++ b/src/LockIn-LakeShore_M81-CM-10/main.py
@@ -143,11 +143,7 @@ class Device(EmptyDevice):
             "Reserve": list(self.filter_optimizations.keys()),
             "Averaging reference cycles": 0,
             "HighPassFilter": ["None"]
-            + [
-                x + ", " + y
-                for x in list(self.cutoff_frequencies.keys())[1:]
-                for y in self.filter_rolloffs.keys()
-            ],
+            + [x + ", " + y for x in list(self.cutoff_frequencies.keys())[1:] for y in self.filter_rolloffs.keys()],
             "LowPassFilter": ["None"]
             + [
                 x + ", " + y
@@ -229,19 +225,13 @@ class Device(EmptyDevice):
             self.filter_on = False
 
         # Digital filter
-        self.high_digital_filter = (
-            True if "ON" in parameter.get("Filter1", "") else False
-        )
+        self.high_digital_filter = True if "ON" in parameter.get("Filter1", "") else False
 
         # Reference wave
         self.lia_harm = parameter.get("Lock-In harmonic", 0)
-        self.lia_ref_phase_shift = parameter.get(
-            "Reference phase shift in degrees", "Auto"
-        )
+        self.lia_ref_phase_shift = parameter.get("Reference phase shift in degrees", "Auto")
 
-        self.freq_range_threshold = parameter.get(
-            "Frequency range threshold factor of -3 dB", 0.1
-        )
+        self.freq_range_threshold = parameter.get("Frequency range threshold factor of -3 dB", 0.1)
         self.darkmode = parameter.get("Turn off LED", False)
 
         self.shortname = "CM-10 @ M" + self.slot
@@ -309,9 +299,7 @@ class Device(EmptyDevice):
                     self.lia_tc = float(val)
                     self.lia_lowpass = True
                 except (ValueError, TypeError) as e:
-                    raise ValueError(
-                        f"Cannot parse time constant sweep value: {val}"
-                    ) from e
+                    raise ValueError(f"Cannot parse time constant sweep value: {val}") from e
             self.set_timeconstant()
 
     def measure(self):
@@ -335,25 +323,17 @@ class Device(EmptyDevice):
     def read_result(self):
         t_start = time.time()
         while True:
-            if time.time() - t_start > (
-                self.port_properties.get("timeout", 0) + self.wait_time
-            ):
+            if time.time() - t_start > (self.port_properties.get("timeout", 0) + self.wait_time):
                 raise RuntimeError(
                     f'Lock-in did not settle within timeout of {self.port_properties.get("timeout")} seconds.'
                 )
             resp = self.port.read().split(",")
-            if (
-                len(resp) == 6
-            ):  # Catch cases where results of both queries get mixed up.
-                if not bool(
-                    int(resp[5])
-                ):  # If settling is not True, the result is settled
+            if len(resp) == 6:  # Catch cases where results of both queries get mixed up.
+                if not bool(int(resp[5])):  # If settling is not True, the result is settled
                     # Fetch DC separately, because it doesn't support FETCh:MULTIple
                     self.port.write(f"FETCh:SENSe{self.slot}:LIA:DC?")
                     dc_resp = self.port.read().split(",")
-                    if (
-                        len(dc_resp) == 1
-                    ):  # Catch cases where results of both queries get mixed up.
+                    if len(dc_resp) == 1:  # Catch cases where results of both queries get mixed up.
                         self.dc = self.lia_convert(dc_resp[0])
                     else:
                         self.dc = float("nan")
@@ -379,12 +359,8 @@ class Device(EmptyDevice):
     def set_range(self):
         if self.range:
             if self.filter_on and self.filter_type == "REServe":
-                if (
-                    self.range == 0.1
-                ):  # CM-10 does not allow this combination. It would quietly reduce the range.
-                    raise ValueError(
-                        "100 mA range cannot be used with filter optimization 'highest reserve'."
-                    )
+                if self.range == 0.1:  # CM-10 does not allow this combination. It would quietly reduce the range.
+                    raise ValueError("100 mA range cannot be used with filter optimization 'highest reserve'.")
             self.port.write(f"SENSe{self.slot}:CURRent:RANGe:AUTO 0")
             self.port.write(f"SENSe{self.slot}:CURRent:RANGe {self.range}")
         else:
@@ -396,24 +372,19 @@ class Device(EmptyDevice):
             try:
                 self.bias_voltage = float(self.bias_voltage)
             except (ValueError, TypeError):
-                raise ValueError(
-                    "Provide float value for the bias voltage or leave empty for no voltage bias."
-                )
+                raise ValueError("Provide float value for the bias voltage or leave empty for no voltage bias.")
             if voltage == 0:
                 self.port.write(f"SENSe{self.slot}:BIAS:VOLTage 0")
             else:
                 if self.filter_on and self.filter_type == "NOISe":
-                    raise ValueError(
-                        "Bias voltage > 0 cannot be used with 'Lowest noise' filter optimization."
-                    )
+                    raise ValueError("Bias voltage > 0 cannot be used with 'Lowest noise' filter optimization.")
                 self.port.write(f"SENSe{self.slot}:BIAS:VOLTage {voltage}")
 
     def check_device(self):
         model = self.port.query(f"SENSe{self.slot}:MODel?")
         if not "CM-10" in model:
             raise ValueError(
-                f"Device connected on channel M{self.slot} does not match this driver. "
-                f"Found: '{model}'"
+                f"Device connected on channel M{self.slot} does not match this driver. " f"Found: '{model}'"
             )
 
     def set_lockin_settings(self):
@@ -434,9 +405,7 @@ class Device(EmptyDevice):
         try:
             self.lia_harm = int(self.lia_harm)
         except (ValueError, TypeError):
-            raise ValueError(
-                "Please enter a valid positive integer value for the reference harmonic."
-            )
+            raise ValueError("Please enter a valid positive integer value for the reference harmonic.")
         if self.lia_harm < 1:
             raise ValueError("Lock-In harmonic must be >= 1")
         self.port.write(f"SENSe{self.slot}:LIA:DHARmonic {self.lia_harm}")
@@ -446,24 +415,15 @@ class Device(EmptyDevice):
             self.lia_avg_ref_cycles = int(self.lia_avg_ref_cycles)
         except (ValueError, TypeError):
             raise ValueError(
-                "Please enter an integer number of averaging reference cycles. "
-                "'0' disables the PSD output filter."
+                "Please enter an integer number of averaging reference cycles. " "'0' disables the PSD output filter."
             )
         if self.lia_avg_ref_cycles == 0:
-            self.port.write(
-                f"SENSe{self.slot}:LIA:AVERage 0"
-            )  # Disable averaging filter
+            self.port.write(f"SENSe{self.slot}:LIA:AVERage 0")  # Disable averaging filter
         else:
             if not (1000000 >= self.lia_avg_ref_cycles >= 1):
-                raise ValueError(
-                    "Number of reference cycles must be >= 1 and <= 1,000,000."
-                )
-            self.port.write(
-                f"SENSe{self.slot}:LIA:AVERage 1"
-            )  # Enable averaging filter
-            self.port.write(
-                f"SENSe{self.slot}:LIA:REFerence:CYCLes {self.lia_avg_ref_cycles}"
-            )
+                raise ValueError("Number of reference cycles must be >= 1 and <= 1,000,000.")
+            self.port.write(f"SENSe{self.slot}:LIA:AVERage 1")  # Enable averaging filter
+            self.port.write(f"SENSe{self.slot}:LIA:REFerence:CYCLes {self.lia_avg_ref_cycles}")
 
         # Phase shift to lock-in reference source
         if self.lia_ref_phase_shift == "Auto":
@@ -472,9 +432,7 @@ class Device(EmptyDevice):
             try:
                 self.lia_ref_phase_shift = float(self.lia_ref_phase_shift)
                 if not (360 >= self.lia_ref_phase_shift >= -360):
-                    raise ValueError(
-                        "Phase shift given as a float that is out of range (+-360°)."
-                    )
+                    raise ValueError("Phase shift given as a float that is out of range (+-360°).")
             except (ValueError, TypeError) as e:
                 raise ValueError(
                     'Reference phase shift must be a float between -360 and +360 degrees or "Auto".'
@@ -487,19 +445,13 @@ class Device(EmptyDevice):
             try:
                 self.wait_time = float(self.wait_time_constants) * float(self.lia_tc)
             except (ValueError, TypeError):
-                raise ValueError(
-                    "'Settling in time constants' must be 'Auto' or a float."
-                )
+                raise ValueError("'Settling in time constants' must be 'Auto' or a float.")
         # Time constant and rolloff for traditional lowpass filter
         # Enable/Disable Lowpass filter
-        self.port.write(
-            f'SENSe{self.slot}:LIA:LPASs {"1" if self.lia_lowpass else "0"}'
-        )
+        self.port.write(f'SENSe{self.slot}:LIA:LPASs {"1" if self.lia_lowpass else "0"}')
         if self.lia_lowpass:
             if not (10000 >= self.lia_tc >= 0.0001):
-                raise ValueError(
-                    f"Lock-In time constant set to {self.lia_tc}. Must be >= 0.0001 s and <= 10,000 s."
-                )
+                raise ValueError(f"Lock-In time constant set to {self.lia_tc}. Must be >= 0.0001 s and <= 10,000 s.")
             self.port.write(f"SENSe{self.slot}:LIA:TIMEconstant {self.lia_tc}")
             self.port.write(f"SENSe{self.slot}:LIA:ROLLoff R{self.lia_rolloff}")
 
@@ -510,9 +462,7 @@ class Device(EmptyDevice):
         else:
             self.port.write(f"SENSe{self.slot}:FILTer:STATe 0")
         self.port.write(f'SENSe{self.slot}:DMODe {"1" if self.darkmode else "0"}')
-        self.port.write(
-            f'SENSe{self.slot}:DIGital:FILTer:HPASs {"1" if self.high_digital_filter else "0"}'
-        )
+        self.port.write(f'SENSe{self.slot}:DIGital:FILTer:HPASs {"1" if self.high_digital_filter else "0"}')
         # Threshold
         try:
             self.freq_range_threshold = float(self.freq_range_threshold)
@@ -522,26 +472,16 @@ class Device(EmptyDevice):
                     "Threshold value is normalized to the -3 dB bandwith of the range."
                 )
         except (ValueError, TypeError) as e:
-            raise ValueError(
-                "Please enter correct value for frequency range threshold."
-            ) from e
+            raise ValueError("Please enter correct value for frequency range threshold.") from e
         self.port.write(f"SENSe{self.slot}:FRTHreshold {self.freq_range_threshold}")
 
     def set_filters(self):
         self.port.write(f"SENSe{self.slot}:FILTer:STATe 1")
         self.port.write(f"SENSe{self.slot}:FILTer:OPTimization {self.filter_type}")
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.low_filter_cornerf}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.low_filter_rolloff}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.high_filter_cornerf}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.high_filter_rolloff}"
-        )
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.low_filter_cornerf}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.low_filter_rolloff}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.high_filter_cornerf}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.high_filter_rolloff}")
 
     @staticmethod
     def lia_convert(value_str: str) -> float:

--- a/src/LockIn-LakeShore_M81-VM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-VM-10/doc/description.md
@@ -61,7 +61,7 @@ Note: the datasheet also lists 30 kHz corner frequencies, but the remote interfa
 ## Digital high pass filter and reference phase
 
 - **High pass digital filter** (Filter1): removes the DC component before the PSD and enables the "Lock-In DC" measurement. Recommended ON.
-- **Reference phase shift**: "Auto" lets the instrument set the phase so that the present, settled signal appears at θ = 0°; "As is" keeps the phase currently stored in the instrument; a numeric value (-360° to +360°) sets it explicitly. "Auto" is executed once during configuration — the reference must already be active and the signal settled at that moment for a correct result.
+- **Reference phase shift**: "Auto" lets the instrument set the phase so that the present, settled signal appears at θ = 0°; "As is" keeps the phase that was set on the instrument before the run started (the driver reads it back before the module preset and restores it afterwards); a numeric value (-360° to +360°) sets it explicitly. "Auto" is executed once during configuration — the reference must already be active and the signal settled at that moment for a correct result.
 
 ## Sweep modes
 

--- a/src/LockIn-LakeShore_M81-VM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-VM-10/doc/description.md
@@ -1,0 +1,69 @@
+# Lock-In driver for the VM-10 module of the LakeShore M81-SSM
+
+- Performs phase-sensitive (lock-in) voltage measurements using the VM-10 voltage measure module of the LakeShore M81 Synchronous Source Measure System.
+- Three physical measure channels (M1, M2, M3) are available on the M81. Connect your VM-10 module to one of them and select the corresponding channel in SweepMe!.
+- For plain DC/AC voltage measurements without lock-in detection, use the Logger driver "Logger-LakeShore_M81-VM-10" instead.
+
+## Returned variables
+
+- **X** - in-phase voltage component (aligned with the reference), in V
+- **Y** - quadrature voltage component (90° out of phase), in V
+- **Magnitude** - R = sqrt(X² + Y²), in V
+- **Phase** - phase angle θ of the signal relative to the reference, in degrees
+- **Frequency** - the detected reference frequency, in Hz
+- **Lock-In DC** - DC component of the input signal, in V (only measured when the "High pass digital filter" is ON, otherwise NaN)
+
+Special values: **+inf** indicates a range overload, **NaN** indicates that the PLL is unlocked or the value is not available. Choose a larger range (or Auto) on overload.
+
+## Reference source
+
+- The lock-in detects signals coherent with the selected reference. Choose the M81 source channel (S1, S2, S3) that excites your sample, or "Reference In" for the external BNC reference input.
+- The lock-in frequency is defined by the reference; it is not set on the VM-10 itself. If no AC source is active, lock-in readings will return zero or noise.
+- The "Lock-In harmonic" allows detection at integer multiples of the reference frequency (e.g. 2 for second-harmonic detection). Harmonic × reference frequency must not exceed 100 kHz.
+
+## Measurement procedure
+
+The driver requests all lock-in values (X, Y, R, θ, frequency) with a single synchronized `FETCh:MULTiple` query together with the instrument's settling flag. If the instrument reports that the measurement is still settling (e.g. after a range change or a new source value), the driver keeps polling until the value is settled or the port timeout (15 s) is exceeded.
+
+- **WaitTimeConstants = "Auto"** (recommended): the driver relies on the instrument's settling flag alone.
+- **WaitTimeConstants = number**: the driver additionally waits this number of time constants before every measurement point. Use this when you sweep a source parameter and want a defined extra settle time, e.g. 5–10 time constants for 0.1 % settling (see the table in the M81 manual, section "Choosing Lock-In Filter Settings").
+
+## Output filters
+
+Two output filters act on the phase-sensitive detector (PSD) output:
+
+- **Traditional low pass filter (IIR)**: configured via "TimeConstant" (0.0001 s to 10,000 s) and "Slope" (6/12/18/24 dB/oct). Longer time constants and steeper slopes reduce the equivalent noise bandwidth at the cost of longer settling. Enter a number to enable it, or select "Traditional low pass output filter OFF" to disable it.
+- **Averaging filter (FIR)**: a moving average over N cycles of the reference frequency, set via "Averaging reference cycles" (0 = off). It strongly rejects the carrier and its harmonics. Note that at low reference frequencies N cycles can take a long time (N / f_ref seconds).
+
+At least one output filter should be enabled for a meaningful lock-in measurement. A good starting point is a time constant of 0.1 s with 12 dB/oct plus 10 averaging reference cycles.
+
+## Sensitivity (input range)
+
+- Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
+- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
+- "Frequency range threshold factor" (0.0–1.0): during autorange, a range is chosen such that the signal frequency does not exceed this fraction of the range's -3 dB bandwidth.
+
+## Input configuration and coupling
+
+- **Input**: "A-B" (differential), "A" (single-ended vs. measure ground), or "Ground" (input internally grounded, e.g. for offset checks).
+- **Coupling**: DC or AC. AC coupling engages a 0.16 Hz high pass and blocks DC signals; note that the input bias current then causes a small DC offset.
+
+## Analog input filter ("Reserve")
+
+The VM-10 contains hardware high pass and low pass filters (corner frequencies 10 Hz to 10 kHz, 6 or 12 dB/oct) in front of the amplifier chain. They are enabled by selecting a filter optimization:
+
+- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads.
+- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise (10 V and 1 V ranges unavailable).
+- **None**: analog input filter off.
+
+Note: the datasheet also lists 30 kHz corner frequencies, but the remote interface manual only documents corner frequencies up to 10 kHz, so this driver offers up to 10 kHz.
+
+## Digital high pass filter and reference phase
+
+- **High pass digital filter** (Filter1): removes the DC component before the PSD and enables the "Lock-In DC" measurement. Recommended ON.
+- **Reference phase shift**: "Auto" lets the instrument set the phase so that the present, settled signal appears at θ = 0°; "As is" keeps the phase currently stored in the instrument; a numeric value (-360° to +360°) sets it explicitly. "Auto" is executed once during configuration — the reference must already be active and the signal settled at that moment for a correct result.
+
+## Sweep modes
+
+- **Sensitivity in V**: sweep the input range (accepts 10, 1, 0.1, 0.01 or the corresponding labels).
+- **Time constant in s**: sweep the IIR output filter time constant.

--- a/src/LockIn-LakeShore_M81-VM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-VM-10/doc/description.md
@@ -41,7 +41,6 @@ At least one output filter should be enabled for a meaningful lock-in measuremen
 
 - Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
 - Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
-- "Frequency range threshold factor" (0.0–1.0): during autorange, a range is chosen such that the signal frequency does not exceed this fraction of the range's -3 dB bandwidth.
 
 ## Input configuration and coupling
 

--- a/src/LockIn-LakeShore_M81-VM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-VM-10/doc/description.md
@@ -12,6 +12,7 @@
 - **Phase** - phase angle θ of the signal relative to the reference, in degrees
 - **Frequency** - the detected reference frequency, in Hz
 - **Lock-In DC** - DC component of the input signal, in V (only measured when the "High pass digital filter" is ON, otherwise NaN)
+- **Resistance In-Phase / Quadrature / Magnitude** (Ohm) and **Resistance Phase** (°) - the instrument's calculated AC resistance using the selected "Resistance source" (see below); NaN if the pairing is not valid
 
 Special values: **+inf** indicates a range overload, **NaN** indicates that the PLL is unlocked or the value is not available. Choose a larger range (or Auto) on overload.
 
@@ -61,6 +62,16 @@ Note: the datasheet also lists 30 kHz corner frequencies, but the remote interfa
 
 - **High pass digital filter** (Filter1): removes the DC component before the PSD and enables the "Lock-In DC" measurement. Recommended ON.
 - **Reference phase shift**: "Auto" lets the instrument set the phase so that the present, settled signal appears at θ = 0°; "As is" keeps the phase that was set on the instrument before the run started (the driver reads it back before the module preset and restores it afterwards); a numeric value (-360° to +360°) sets it explicitly. "Auto" is executed once during configuration — the reference must already be active and the signal settled at that moment for a correct result.
+
+## Calculated resistance ("Resistance source")
+
+The M81 calculates a resistance by pairing this VM-10 with a current-type module: select the module that drives or measures the current through your sample (e.g. a BCS-10 source or a CM-10 measure module) as "Resistance source" (default: S1, matching the instrument default). The driver always returns **Resistance In-Phase**, **Resistance Quadrature**, **Resistance Magnitude** (all in Ohm), and **Resistance Phase** (in °), calculated by the instrument from time-synchronized readings. If the selected pairing is not valid for your setup, these values are simply NaN and can be ignored.
+
+Notes:
+
+- Selecting a resistance source in lock-in mode also sets the lock-in reference source on the instrument; the driver therefore writes the resistance source first and your "Source" selection afterwards, so the reference you chose always wins.
+- The paired module must use current units; pairing with another voltage module (e.g. VS-10) is incompatible and yields NaN. The values are also NaN when a paired module reports an error or the source amplitude is 0.
+- The driver intentionally does not touch the instrument's resistance excitation type, optimization, or resistance range settings, since these would reconfigure the source module behind the back of the driver controlling it. Configure the source module (sine shape, amplitude, frequency) with its own SweepMe! driver.
 
 ## Sweep modes
 

--- a/src/LockIn-LakeShore_M81-VM-10/doc/description.md
+++ b/src/LockIn-LakeShore_M81-VM-10/doc/description.md
@@ -11,7 +11,7 @@
 - **Magnitude** - R = sqrt(X² + Y²), in V
 - **Phase** - phase angle θ of the signal relative to the reference, in degrees
 - **Frequency** - the detected reference frequency, in Hz
-- **Lock-In DC** - DC component of the input signal, in V (only measured when the "High pass digital filter" is ON, otherwise NaN)
+- **Lock-In DC** - DC component of the input signal, in V (only measured when the "high-pass digital filter" is ON, otherwise NaN)
 - **Resistance In-Phase / Quadrature / Magnitude** (Ohm) and **Resistance Phase** (°) - the instrument's calculated AC resistance using the selected "Resistance source" (see below); NaN if the pairing is not valid
 
 Special values: **+inf** indicates a range overload, **NaN** indicates that the PLL is unlocked or the value is not available. Choose a larger range (or Auto) on overload.
@@ -33,7 +33,7 @@ The driver requests all lock-in values (X, Y, R, θ, frequency) with a single sy
 
 Two output filters act on the phase-sensitive detector (PSD) output:
 
-- **Traditional low pass filter (IIR)**: configured via "TimeConstant" (0.0001 s to 10,000 s) and "Slope" (6/12/18/24 dB/oct). Longer time constants and steeper slopes reduce the equivalent noise bandwidth at the cost of longer settling. Enter a number to enable it, or select "Traditional low pass output filter OFF" to disable it.
+- **Traditional low-pass filter (IIR)**: configured via "TimeConstant" (0.0001 s to 10,000 s) and "Slope" (6/12/18/24 dB/oct). Longer time constants and steeper slopes reduce the equivalent noise bandwidth at the cost of longer settling. Enter a number to enable it, or select "Traditional low-pass output filter OFF" to disable it.
 - **Averaging filter (FIR)**: a moving average over N cycles of the reference frequency, set via "Averaging reference cycles" (0 = off). It strongly rejects the carrier and its harmonics. Note that at low reference frequencies N cycles can take a long time (N / f_ref seconds).
 
 At least one output filter should be enabled for a meaningful lock-in measurement. A good starting point is a time constant of 0.1 s with 12 dB/oct plus 10 averaging reference cycles.
@@ -41,26 +41,26 @@ At least one output filter should be enabled for a meaningful lock-in measuremen
 ## Sensitivity (input range)
 
 - Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
-- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
+- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Lowest noise". The driver raises an error for this combination.
 
 ## Input configuration and coupling
 
 - **Input**: "A-B" (differential), "A" (single-ended vs. measure ground), or "Ground" (input internally grounded, e.g. for offset checks).
-- **Coupling**: DC or AC. AC coupling engages a 0.16 Hz high pass and blocks DC signals; note that the input bias current then causes a small DC offset.
+- **Coupling**: DC or AC. AC coupling engages a 0.16 Hz high-pass and blocks DC signals; note that the input bias current then causes a small DC offset.
 
 ## Analog input filter ("Reserve")
 
-The VM-10 contains hardware high pass and low pass filters (corner frequencies 10 Hz to 10 kHz, 6 or 12 dB/oct) in front of the amplifier chain. They are enabled by selecting a filter optimization:
+The VM-10 contains hardware high-pass and low-pass filters (corner frequencies 10 Hz to 10 kHz, 6 or 12 dB/oct) in front of the amplifier chain. They are enabled by selecting a filter optimization:
 
-- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads.
-- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise (10 V and 1 V ranges unavailable).
+- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads (10 V and 1 V ranges unavailable).
+- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise.
 - **None**: analog input filter off.
 
 Note: the datasheet also lists 30 kHz corner frequencies, but the remote interface manual only documents corner frequencies up to 10 kHz, so this driver offers up to 10 kHz.
 
-## Digital high pass filter and reference phase
+## Digital high-pass filter and reference phase
 
-- **High pass digital filter** (Filter1): removes the DC component before the PSD and enables the "Lock-In DC" measurement. Recommended ON.
+- **high-pass digital filter** (Filter1): removes the DC component before the PSD and enables the "Lock-In DC" measurement. Recommended ON.
 - **Reference phase shift**: "Auto" lets the instrument set the phase so that the present, settled signal appears at θ = 0°; "As is" keeps the phase that was set on the instrument before the run started (the driver reads it back before the module preset and restores it afterwards); a numeric value (-360° to +360°) sets it explicitly. "Auto" is executed once during configuration — the reference must already be active and the signal settled at that moment for a correct result.
 
 ## Calculated resistance ("Resistance source")

--- a/src/LockIn-LakeShore_M81-VM-10/license.txt
+++ b/src/LockIn-LakeShore_M81-VM-10/license.txt
@@ -1,0 +1,26 @@
+This Device Class is published under the terms of the MIT License.
+Required Third Party Libraries, which are included in the Device Class
+package for convenience purposes, may have a different license. You can
+find those in the corresponding folders or contact the maintainer.
+
+MIT License
+
+Copyright (c) 2025 SweepMe! GmbH (sweep-me.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -128,7 +128,6 @@ class Device(EmptyDevice):
         self.highpass_corner: str = "NONE"
         self.highpass_rolloff: int = 6
         self.digital_highpass: bool = True
-        self.freq_range_threshold: float = 0.1
         self.darkmode: bool = False
 
         # Result parameters
@@ -185,7 +184,6 @@ class Device(EmptyDevice):
                 "Filter1": ["High pass digital filter ON", "High pass digital filter OFF"],
                 "Lock-In harmonic": 1,
                 "Reference phase shift in degrees": ["Auto", "As is", "0.0 (edit)"],
-                "Frequency range threshold factor of -3 dB": 0.1,
                 "": None,  # empty line
                 "Turn off LED": False,
             }
@@ -240,7 +238,6 @@ class Device(EmptyDevice):
 
         self.digital_highpass = "ON" in str(parameters.get("Filter1", "ON"))
         self.lia_phase_mode = str(parameters.get("Reference phase shift in degrees", "Auto"))
-        self.freq_range_threshold = parameters.get("Frequency range threshold factor of -3 dB", 0.1)
         self.darkmode = bool(parameters.get("Turn off LED", False))
 
         self.shortname = f"VM-10 @ M{self.slot}"
@@ -500,22 +497,8 @@ class Device(EmptyDevice):
         self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
 
     def set_advanced_settings(self) -> None:
-        """Configure the digital high pass filter, autorange frequency threshold, and dark mode."""
+        """Configure the digital high pass filter and dark mode."""
         self.port.write(f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}")
-
-        try:
-            threshold = float(self.freq_range_threshold)
-        except (ValueError, TypeError) as e:
-            msg = "Please enter a number for the frequency range threshold."
-            raise ValueError(msg) from e
-        if not 0.0 <= threshold <= 1.0:
-            msg = (
-                "The frequency range threshold must be between 0.0 and 1.0. "
-                "It is normalized to the -3 dB bandwidth of the range."
-            )
-            raise ValueError(msg)
-        self.port.write(f"SENSe{self.slot}:FRTHreshold {threshold}")
-
         self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
 
     def request_lockin_snapshot(self) -> None:

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -1,0 +1,553 @@
+# This Device Class is published under the terms of the MIT License.
+# Required Third Party Libraries, which are included in the Device Class
+# package for convenience purposes, may have a different license. You can
+# find those in the corresponding folders or contact the maintainer.
+#
+# MIT License
+#
+# Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# SweepMe! driver
+# * Module: LockIn
+# * Instrument: LakeShore M81 VM-10
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from pysweepme.EmptyDeviceClass import EmptyDevice  # Class comes with SweepMe!
+
+
+class Device(EmptyDevice):
+    """SweepMe! LockIn driver for the VM-10 voltage measure module of the LakeShore M81-SSM.
+
+    The VM-10 is operated in lock-in (LIA) mode and performs phase-sensitive voltage
+    detection at the frequency of the selected reference source (any M81 source channel
+    or the external reference input). The driver returns X, Y, magnitude R, phase theta,
+    the reference frequency, and the lock-in DC component.
+    """
+
+    def __init__(self) -> None:
+        """Initialize driver parameters and option-to-command dictionaries."""
+        EmptyDevice.__init__(self)
+
+        self.shortname = "M81 VM-10"
+
+        self.port_manager = True
+        self.port_types = ["COM", "GPIB", "TCPIP", "SOCKET"]
+
+        self.port_properties = {
+            "baudrate": 921600,  # fixed baud rate of the M81 USB serial interface
+            "EOL": "\n",
+            "timeout": 15,
+            "TCPIP_EOLwrite": "\n",
+            "TCPIP_EOLread": "\n",
+            "SOCKET_EOLwrite": "\n",
+            "SOCKET_EOLread": "\n",
+        }
+
+        # Voltage ranges of the VM-10 in V; 0.0 stands for autorange
+        self.voltage_ranges: dict[str, float] = {
+            "Auto": 0.0,
+            "10 V": 10.0,
+            "1 V": 1.0,
+            "100 mV": 0.1,
+            "10 mV": 0.01,
+        }
+
+        # Input configurations of the VM-10
+        self.input_configurations: dict[str, str] = {
+            "A-B": "AB",
+            "A": "A",
+            "Ground": "GROund",
+        }
+
+        # Corner frequency options for the analog input high/low pass filters
+        self.cutoff_frequencies: dict[str, str] = {
+            "None": "NONE",
+            "10 Hz": "F10",
+            "30 Hz": "F30",
+            "100 Hz": "F100",
+            "300 Hz": "F300",
+            "1 kHz": "F1000",
+            "3 kHz": "F3000",
+            "10 kHz": "F10000",
+        }
+
+        # Rolloff options for the analog input high/low pass filters
+        self.filter_rolloffs: dict[str, int] = {"6 dB/oct": 6, "12 dB/oct": 12}
+
+        # Analog input filter optimization modes ('Reserve' in the SweepMe! LockIn GUI)
+        self.filter_optimizations: dict[str, str] = {
+            "None (analog input filter off)": "",
+            "Lowest noise": "NOISe",
+            "Highest reserve": "REServe",
+        }
+
+        # Measurement parameters set via the GUI
+        self.slot: str = ""  # measure channel number "1", "2", or "3"
+        self.port_string: str = ""
+        self.sweep_mode: str = "None"
+        self.range: float = 0.0  # 0.0 = autorange
+        self.input_config: str = "AB"
+        self.coupling: str = "DC"
+        self.lia_ref: str = "S1"
+        self.lia_harmonic: int = 1
+        self.lia_lowpass: bool = True  # traditional IIR low pass output filter on/off
+        self.lia_tc: float = 0.1  # time constant of the IIR output filter in s
+        self.lia_rolloff: int = 12  # rolloff of the IIR output filter in dB/oct
+        self.lia_avg_ref_cycles: int = 0  # 0 disables the FIR averaging output filter
+        self.lia_phase_mode: str = "Auto"  # "Auto", "As is", or a float as string
+        self.lia_phase_shift: float = 0.0
+        self.wait_time_constants: str = "Auto"
+        self.wait_time: float = 0.0  # additional settle wait per point in s
+        self.filter_on: bool = False
+        self.filter_optimization: str = "NOISe"
+        self.lowpass_corner: str = "NONE"
+        self.lowpass_rolloff: int = 6
+        self.highpass_corner: str = "NONE"
+        self.highpass_rolloff: int = 6
+        self.digital_highpass: bool = True
+        self.freq_range_threshold: float = 0.1
+        self.darkmode: bool = False
+
+        # Result parameters
+        self.x_lia: float = float("nan")
+        self.y_lia: float = float("nan")
+        self.r_lia: float = float("nan")
+        self.theta_lia: float = float("nan")
+        self.freq_lia: float = float("nan")
+        self.dc_lia: float = float("nan")
+
+        self.variables = ["X", "Y", "Magnitude", "Phase", "Frequency", "Lock-In DC"]
+        self.units = ["V", "V", "V", "°", "Hz", "V"]
+        self.plottype = [True] * len(self.variables)
+        self.savetype = [True] * len(self.variables)
+
+    def update_gui_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Return a dictionary of GUI fields and defaults depending on the current parameters."""
+        gui_parameters: dict[str, Any] = {
+            "SweepMode": ["None", "Sensitivity in V", "Time constant in s"],
+            "Channel": ["M1", "M2", "M3"],  # physical measure channels of the M81
+            "Source": ["S1", "S2", "S3", "Reference In"],  # lock-in reference source
+            "Input": list(self.input_configurations.keys()),
+            "Coupling": ["DC", "AC"],
+            "Sensitivity": list(self.voltage_ranges.keys()),
+            "TimeConstant": ["0.1 (edit)", "Traditional low pass output filter OFF"],
+            "Slope": [
+                "6 dB/oct (output filter)",
+                "12 dB/oct (output filter)",
+                "18 dB/oct (output filter)",
+                "24 dB/oct (output filter)",
+            ],
+            "WaitTimeConstants": "Auto",
+            "Averaging reference cycles": 0,
+            "Reserve": list(self.filter_optimizations.keys()),
+        }
+
+        # The analog input high/low pass filters are only active
+        # if a filter optimization ('Reserve') is selected.
+        reserve = parameters.get("Reserve", "")
+        if reserve and self.filter_optimizations.get(reserve, ""):
+            gui_parameters["HighPassFilter"] = ["None"] + [
+                f"{corner}, {rolloff}"
+                for corner in list(self.cutoff_frequencies.keys())[1:]
+                for rolloff in self.filter_rolloffs
+            ]
+            gui_parameters["LowPassFilter"] = ["None"] + [
+                f"{corner}, {rolloff}"
+                for corner in reversed(list(self.cutoff_frequencies.keys())[1:])
+                for rolloff in self.filter_rolloffs
+            ]
+
+        gui_parameters.update(
+            {
+                "Filter1": ["High pass digital filter ON", "High pass digital filter OFF"],
+                "Lock-In harmonic": 1,
+                "Reference phase shift in degrees": ["Auto", "As is", "0.0 (edit)"],
+                "Frequency range threshold factor of -3 dB": 0.1,
+                "": None,  # empty line
+                "Turn off LED": False,
+            }
+        )
+        return gui_parameters
+
+    def apply_gui_parameters(self, parameters: dict[str, Any]) -> None:
+        """Read the GUI parameters selected by the user and store them in driver attributes."""
+        channel = str(parameters.get("Channel", ""))
+        if channel.strip().lower() in ("m1", "m2", "m3"):
+            self.slot = channel.strip()[1]  # e.g. "1" for "M1"
+        else:
+            self.slot = ""
+
+        self.port_string = parameters.get("Port", "")
+        self.sweep_mode = parameters.get("SweepMode", "None")
+        self.range = self.voltage_ranges.get(parameters.get("Sensitivity", "Auto"), 0.0)
+        self.input_config = self.input_configurations.get(parameters.get("Input", "A-B"), "AB")
+        self.coupling = parameters.get("Coupling", "DC")
+        self.lia_ref = parameters.get("Source", "S1")
+        self.lia_harmonic = parameters.get("Lock-In harmonic", 1)
+        self.lia_avg_ref_cycles = parameters.get("Averaging reference cycles", 0)
+        self.wait_time_constants = str(parameters.get("WaitTimeConstants", "Auto"))
+
+        # Traditional IIR low pass output filter: a numeric entry is the time constant,
+        # any non-numeric entry (e.g. "Traditional low pass output filter OFF") disables it.
+        raw_tc = str(parameters.get("TimeConstant", "0.1"))
+        try:
+            self.lia_tc = float(raw_tc.split(" ")[0])
+            self.lia_lowpass = True
+        except (ValueError, TypeError):
+            self.lia_lowpass = False
+
+        raw_slope = str(parameters.get("Slope", "12"))
+        try:
+            self.lia_rolloff = int(raw_slope.split(" ")[0])
+        except (ValueError, TypeError):
+            self.lia_rolloff = 12
+
+        # Analog input filter ('Reserve' selects the filter optimization)
+        self.filter_optimization = self.filter_optimizations.get(parameters.get("Reserve", ""), "")
+        self.filter_on = bool(self.filter_optimization)
+        if self.filter_on:
+            lowpass = str(parameters.get("LowPassFilter", "None")).split(",")
+            self.lowpass_corner = self.cutoff_frequencies.get(lowpass[0].strip(), "NONE")
+            if len(lowpass) > 1:
+                self.lowpass_rolloff = self.filter_rolloffs.get(lowpass[1].strip(), 6)
+            highpass = str(parameters.get("HighPassFilter", "None")).split(",")
+            self.highpass_corner = self.cutoff_frequencies.get(highpass[0].strip(), "NONE")
+            if len(highpass) > 1:
+                self.highpass_rolloff = self.filter_rolloffs.get(highpass[1].strip(), 6)
+
+        self.digital_highpass = "ON" in str(parameters.get("Filter1", "ON"))
+        self.lia_phase_mode = str(parameters.get("Reference phase shift in degrees", "Auto"))
+        self.freq_range_threshold = parameters.get("Frequency range threshold factor of -3 dB", 0.1)
+        self.darkmode = bool(parameters.get("Turn off LED", False))
+
+        self.shortname = f"VM-10 @ M{self.slot}"
+
+    # --- semantic standard functions called by SweepMe! during a measurement ---
+
+    def initialize(self) -> None:
+        """Check channel selection and connected module, then load the module defaults."""
+        if not self.slot:
+            msg = "Please give a correct channel number (M1, M2 or M3)."
+            raise ValueError(msg)
+        self.check_device()
+        self.port.write(f"SENSe{self.slot}:PRESet")  # reset module to power-on defaults
+
+    def configure(self) -> None:
+        """Write all GUI settings to the instrument."""
+        self.set_mode("LIA")
+        self.set_input_configuration(self.input_config)
+        self.set_coupling(self.coupling)
+        self.set_analog_filter()  # set filters before range: the range limits depend on them
+        self.set_range()
+        self.set_time_constant()
+        self.set_lockin_settings()
+        self.set_advanced_settings()
+
+    def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
+        """Reapply the configuration when a GUI parameter changes during a run via the {...} parameter system."""
+        if parameters:
+            self.apply_gui_parameters(parameters)
+        self.configure()
+
+    def apply(self) -> None:
+        """Apply a new sweep value (self.value) according to the selected sweep mode."""
+        if self.sweep_mode == "Sensitivity in V":
+            value = self.value
+            if isinstance(value, str) and value in self.voltage_ranges:
+                self.range = self.voltage_ranges[value]
+            else:
+                try:
+                    self.range = float(value)
+                except (ValueError, TypeError) as e:
+                    msg = f"Cannot parse sensitivity sweep value: {value}"
+                    raise ValueError(msg) from e
+            self.set_range()
+
+        elif self.sweep_mode == "Time constant in s":
+            value = self.value
+            if isinstance(value, str) and "off" in value.lower():
+                self.lia_lowpass = False
+            else:
+                try:
+                    self.lia_tc = float(value)
+                    self.lia_lowpass = True
+                except (ValueError, TypeError) as e:
+                    msg = f"Cannot parse time constant sweep value: {value}"
+                    raise ValueError(msg) from e
+            self.set_time_constant()
+
+    def measure(self) -> None:
+        """Wait the requested settle time, then request a synchronized snapshot of all lock-in values."""
+        if self.wait_time > 0:
+            # Additional wait of N time constants, e.g. after a source module changed its value.
+            # Sleep in small steps so the user can stop the run at any time.
+            start_time = time.time()
+            while not self.is_run_stopped() and time.time() - start_time < self.wait_time:
+                time.sleep(min(0.05, self.wait_time))
+        self.request_lockin_snapshot()
+
+    def read_result(self) -> None:
+        """Read the snapshot and repeat the query until the instrument reports settled values."""
+        timeout = float(self.port_properties.get("timeout", 15))
+        start_time = time.time()
+        while True:
+            response = self.port.read().split(",")
+            if len(response) == 6:
+                settling = bool(int(float(response[5])))
+                if not settling:
+                    break
+            if self.is_run_stopped():
+                return
+            if time.time() - start_time > timeout + self.wait_time:
+                msg = f"Lock-in did not settle within the timeout of {timeout} s."
+                raise TimeoutError(msg)
+            time.sleep(0.05)
+            self.request_lockin_snapshot()
+
+        self.x_lia = self.convert_measurement(response[0])
+        self.y_lia = self.convert_measurement(response[1])
+        self.r_lia = self.convert_measurement(response[2])
+        self.theta_lia = self.convert_measurement(response[3])
+        self.freq_lia = self.convert_measurement(response[4])
+
+        # The lock-in DC component is not available via FETCh:MULTiple and is queried separately.
+        # It is only measured by the instrument when the high pass digital filter is enabled.
+        if self.digital_highpass:
+            dc_response = self.port.query(f"FETCh:SENSe{self.slot}:LIA:DC?")
+            self.dc_lia = self.convert_measurement(dc_response)
+        else:
+            self.dc_lia = float("nan")
+
+    def call(self) -> list[float]:
+        """Return the measurement results in the order of self.variables."""
+        return [self.x_lia, self.y_lia, self.r_lia, self.theta_lia, self.freq_lia, self.dc_lia]
+
+    # --- wrapped functions ---
+
+    def check_device(self) -> None:
+        """Verify that the module connected to the selected channel is a VM-10."""
+        model = self.port.query(f"SENSe{self.slot}:MODel?")
+        if "VM-10" not in model:
+            msg = (
+                f"Device connected on channel M{self.slot} does not match this driver. "
+                f"Found: '{model}'"
+            )
+            raise ValueError(msg)
+
+    def set_mode(self, mode: str) -> None:
+        """Set the measurement mode of the module (DC, AC, or LIA)."""
+        self.port.write(f"SENSe{self.slot}:MODE {mode}")
+
+    def set_input_configuration(self, input_config: str) -> None:
+        """Set the input configuration (AB, A, or GROund)."""
+        self.port.write(f"SENSe{self.slot}:CONFiguration {input_config}")
+
+    def set_coupling(self, coupling: str) -> None:
+        """Set the input coupling (DC or AC)."""
+        if coupling not in ("DC", "AC"):
+            msg = f"Invalid coupling '{coupling}'. Use 'DC' or 'AC'."
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:COUPling {coupling}")
+
+    def set_range(self) -> None:
+        """Set the voltage range or enable autorange (self.range == 0.0)."""
+        if self.range:
+            if self.range not in self.voltage_ranges.values():
+                msg = (
+                    f"Invalid sensitivity '{self.range}'. "
+                    f"The VM-10 supports 10 V, 1 V, 0.1 V, and 0.01 V."
+                )
+                raise ValueError(msg)
+            if self.filter_on and self.filter_optimization == "REServe" and self.range > 0.1:
+                # The VM-10 does not support this combination. It would quietly reduce the range.
+                msg = (
+                    "The 10 V and 1 V ranges cannot be used while the analog input filter "
+                    "is enabled with filter optimization 'Highest reserve'."
+                )
+                raise ValueError(msg)
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 0")
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe {self.range}")
+        else:
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 1")
+
+    def set_time_constant(self) -> None:
+        """Configure the traditional IIR low pass output filter and the settle wait time."""
+        # Additional wait time per measurement point in units of the time constant
+        if self.wait_time_constants.strip().lower() == "auto":
+            # Rely on the instrument's settling flag, no additional wait
+            self.wait_time = 0.0
+        else:
+            try:
+                self.wait_time = float(self.wait_time_constants) * (self.lia_tc if self.lia_lowpass else 0.0)
+            except (ValueError, TypeError) as e:
+                msg = "'WaitTimeConstants' must be 'Auto' or a number."
+                raise ValueError(msg) from e
+
+        self.port.write(f"SENSe{self.slot}:LIA:LPASs {'1' if self.lia_lowpass else '0'}")
+        if self.lia_lowpass:
+            if not 0.0001 <= self.lia_tc <= 10000:
+                msg = f"Lock-In time constant is {self.lia_tc} s. Must be between 0.0001 s and 10,000 s."
+                raise ValueError(msg)
+            if self.lia_rolloff not in (6, 12, 18, 24):
+                msg = f"Invalid output filter slope '{self.lia_rolloff}'. Use 6, 12, 18, or 24 dB/oct."
+                raise ValueError(msg)
+            self.port.write(f"SENSe{self.slot}:LIA:TIMEconstant {self.lia_tc}")
+            self.port.write(f"SENSe{self.slot}:LIA:ROLLoff R{self.lia_rolloff}")
+
+    def set_lockin_settings(self) -> None:
+        """Configure reference source, harmonic, FIR averaging filter, and reference phase shift."""
+        # Reference source
+        reference = self.lia_ref
+        if reference not in ("S1", "S2", "S3"):
+            if reference.lower().startswith("reference"):
+                reference = "RIN"  # external reference input
+            else:
+                msg = f"No valid reference source selected: {self.lia_ref}."
+                raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:LIA:RSOurce {reference}")
+
+        # Reference harmonic
+        try:
+            harmonic = int(self.lia_harmonic)
+        except (ValueError, TypeError) as e:
+            msg = "Please enter a positive integer for the lock-in harmonic."
+            raise ValueError(msg) from e
+        if harmonic < 1:
+            msg = "The lock-in harmonic must be >= 1."
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:LIA:DHARmonic {harmonic}")
+
+        # FIR averaging output filter over N cycles of the reference frequency
+        try:
+            cycles = int(self.lia_avg_ref_cycles)
+        except (ValueError, TypeError) as e:
+            msg = (
+                "Please enter an integer number of averaging reference cycles. "
+                "'0' disables the averaging output filter."
+            )
+            raise ValueError(msg) from e
+        if cycles == 0:
+            self.port.write(f"SENSe{self.slot}:LIA:AVERage 0")
+        else:
+            if not 1 <= cycles <= 1000000:
+                msg = "The number of averaging reference cycles must be between 1 and 1,000,000."
+                raise ValueError(msg)
+            self.port.write(f"SENSe{self.slot}:LIA:AVERage 1")
+            self.port.write(f"SENSe{self.slot}:LIA:REFerence:CYCLes {cycles}")
+
+        # Reference phase shift
+        phase_mode = self.lia_phase_mode.strip()
+        if phase_mode.lower() == "auto":
+            # The instrument sets the phase shift so that the present signal appears at 0°.
+            # Note: the measurement should be settled when this command is sent.
+            self.port.write(f"SENSe{self.slot}:LIA:DPHase:AUTO")
+        elif phase_mode.lower() == "as is":
+            pass  # keep the phase shift currently set on the instrument
+        else:
+            try:
+                self.lia_phase_shift = float(phase_mode.split(" ")[0])
+            except (ValueError, TypeError) as e:
+                msg = (
+                    "The reference phase shift must be 'Auto', 'As is', "
+                    "or a number between -360 and +360 degrees."
+                )
+                raise ValueError(msg) from e
+            if not -360 <= self.lia_phase_shift <= 360:
+                msg = "The reference phase shift must be between -360 and +360 degrees."
+                raise ValueError(msg)
+            self.port.write(f"SENSe{self.slot}:LIA:DPHase {self.lia_phase_shift}")
+
+    def set_analog_filter(self) -> None:
+        """Configure the analog input filter of the VM-10 (hardware high/low pass)."""
+        if not self.filter_on:
+            self.port.write(f"SENSe{self.slot}:FILTer:STATe 0")
+            return
+        self.port.write(f"SENSe{self.slot}:FILTer:STATe 1")
+        self.port.write(f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
+
+    def set_advanced_settings(self) -> None:
+        """Configure the digital high pass filter, autorange frequency threshold, and dark mode."""
+        self.port.write(f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}")
+
+        try:
+            threshold = float(self.freq_range_threshold)
+        except (ValueError, TypeError) as e:
+            msg = "Please enter a number for the frequency range threshold."
+            raise ValueError(msg) from e
+        if not 0.0 <= threshold <= 1.0:
+            msg = (
+                "The frequency range threshold must be between 0.0 and 1.0. "
+                "It is normalized to the -3 dB bandwidth of the range."
+            )
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:FRTHreshold {threshold}")
+
+        self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
+
+    def request_lockin_snapshot(self) -> None:
+        """Request a time-synchronized snapshot of all lock-in readings and the settling flag."""
+        self.port.write(
+            f"FETCh:MULTiple? "
+            f"MX,{self.slot},"
+            f"MY,{self.slot},"
+            f"MR,{self.slot},"
+            f"MTHeta,{self.slot},"
+            f"MRFRequency,{self.slot},"
+            f"MSETtling,{self.slot}"
+        )
+
+    def get_settle_time(self, settle_percent: float = 0.1) -> float:
+        """Query the lock-in settle time in s for the given settle percentage (e.g. 0.1 = 0.1 %)."""
+        return float(self.port.query(f"SENSe{self.slot}:LIA:STIMe? {settle_percent}"))
+
+    def get_equivalent_noise_bandwidth(self) -> float:
+        """Query the equivalent noise bandwidth (ENBW) of the lock-in output filters in Hz."""
+        return float(self.port.query(f"SENSe{self.slot}:LIA:ENBW?"))
+
+    def is_locked(self) -> bool:
+        """Query whether the lock-in PLL is locked to the reference signal."""
+        return bool(int(self.port.query(f"FETCh:SENSe{self.slot}:LIA:LOCK?")))
+
+    @staticmethod
+    def convert_measurement(value_string: str) -> float:
+        """Convert an M81 reading to float, mapping the SCPI sentinel values.
+
+        The M81 uses two special values:
+        * 9.90e37 -> measurement overload -> converted to +inf
+        * 9.91e37 -> PLL unlocked or value invalid/settling -> converted to NaN
+        """
+        try:
+            value = float(value_string)
+        except (ValueError, TypeError):
+            return float("nan")
+        if value == 9.90e37:
+            return float("inf")
+        if value == 9.91e37:
+            return float("nan")
+        return value

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -118,6 +118,7 @@ class Device(EmptyDevice):
         self.lia_avg_ref_cycles: int = 0  # 0 disables the FIR averaging output filter
         self.lia_phase_mode: str = "Auto"  # "Auto", "As is", or a float as string
         self.lia_phase_shift: float = 0.0
+        self.stored_phase_shift: float = 0.0  # phase read back before PRESet for 'As is'
         self.wait_time_constants: str = "Auto"
         self.wait_time: float = 0.0  # additional settle wait per point in s
         self.filter_on: bool = False
@@ -252,6 +253,11 @@ class Device(EmptyDevice):
             msg = "Please give a correct channel number (M1, M2 or M3)."
             raise ValueError(msg)
         self.check_device()
+        if self.lia_phase_mode.strip().lower() == "as is":
+            # PRESet below resets the reference phase shift to its power-on default.
+            # Remember the phase currently set on the instrument so that
+            # set_lockin_settings() can restore it afterwards.
+            self.stored_phase_shift = float(self.port.query(f"SENSe{self.slot}:LIA:DPHase?"))
         self.port.write(f"SENSe{self.slot}:PRESet")  # reset module to power-on defaults
 
     def configure(self) -> None:
@@ -464,7 +470,9 @@ class Device(EmptyDevice):
             # Note: the measurement should be settled when this command is sent.
             self.port.write(f"SENSe{self.slot}:LIA:DPHase:AUTO")
         elif phase_mode.lower() == "as is":
-            pass  # keep the phase shift currently set on the instrument
+            # Restore the phase shift that was set on the instrument before the run,
+            # because the module preset during initialize() has reset it.
+            self.port.write(f"SENSe{self.slot}:LIA:DPHase {self.stored_phase_shift}")
         else:
             try:
                 self.lia_phase_shift = float(phase_mode.split(" ")[0])

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -129,6 +129,7 @@ class Device(EmptyDevice):
         self.highpass_rolloff: int = 6
         self.digital_highpass: bool = True
         self.darkmode: bool = False
+        self.resistance_source: str = "S1"  # partner module for calculated AC resistance
 
         # Result parameters
         self.x_lia: float = float("nan")
@@ -137,6 +138,7 @@ class Device(EmptyDevice):
         self.theta_lia: float = float("nan")
         self.freq_lia: float = float("nan")
         self.dc_lia: float = float("nan")
+        self.resistance_results: list[float] = [float("nan")] * 4
 
         self.variables = ["X", "Y", "Magnitude", "Phase", "Frequency", "Lock-In DC"]
         self.units = ["V", "V", "V", "°", "Hz", "V"]
@@ -184,6 +186,9 @@ class Device(EmptyDevice):
                 "Filter1": ["High pass digital filter ON", "High pass digital filter OFF"],
                 "Lock-In harmonic": 1,
                 "Reference phase shift in degrees": ["Auto", "As is", "0.0 (edit)"],
+                # Calculated resistance: pair this VM-10 with a current-type module.
+                # The instrument always has a resistance source selected (default S1).
+                "Resistance source": ["S1", "S2", "S3", "M1", "M2", "M3"],
                 "": None,  # empty line
                 "Turn off LED": False,
             }
@@ -239,8 +244,25 @@ class Device(EmptyDevice):
         self.digital_highpass = "ON" in str(parameters.get("Filter1", "ON"))
         self.lia_phase_mode = str(parameters.get("Reference phase shift in degrees", "Auto"))
         self.darkmode = bool(parameters.get("Turn off LED", False))
+        self.resistance_source = str(parameters.get("Resistance source", "S1"))
 
         self.shortname = f"VM-10 @ M{self.slot}"
+
+        self.variables = [
+            "X",
+            "Y",
+            "Magnitude",
+            "Phase",
+            "Frequency",
+            "Lock-In DC",
+            "Resistance In-Phase",
+            "Resistance Quadrature",
+            "Resistance Magnitude",
+            "Resistance Phase",
+        ]
+        self.units = ["V", "V", "V", "°", "Hz", "V", "Ohm", "Ohm", "Ohm", "°"]
+        self.plottype = [True] * len(self.variables)
+        self.savetype = [True] * len(self.variables)
 
     # --- semantic standard functions called by SweepMe! during a measurement ---
 
@@ -265,6 +287,9 @@ class Device(EmptyDevice):
         self.set_analog_filter()  # set filters before range: the range limits depend on them
         self.set_range()
         self.set_time_constant()
+        # The resistance source must be set before the lock-in settings: in lock-in mode,
+        # writing the resistance source also overwrites the lock-in reference source.
+        self.set_resistance_source()
         self.set_lockin_settings()
         self.set_advanced_settings()
 
@@ -343,9 +368,17 @@ class Device(EmptyDevice):
         else:
             self.dc_lia = float("nan")
 
+        # Calculated AC resistance from this module and the selected resistance source.
+        # The instrument returns NaN if the pairing is incompatible or a module has an error.
+        self.resistance_results = []
+        for quantity in ("INPHase", "QUADrature", "MAGNitude", "PHASe"):
+            response = self.port.query(f"CALCulate:SENSe{self.slot}:RESistance:{quantity}?")
+            self.resistance_results.append(self.convert_measurement(response))
+
     def call(self) -> list[float]:
         """Return the measurement results in the order of self.variables."""
-        return [self.x_lia, self.y_lia, self.r_lia, self.theta_lia, self.freq_lia, self.dc_lia]
+        results = [self.x_lia, self.y_lia, self.r_lia, self.theta_lia, self.freq_lia, self.dc_lia]
+        return results + self.resistance_results
 
     # --- wrapped functions ---
 
@@ -483,6 +516,22 @@ class Device(EmptyDevice):
                 msg = "The reference phase shift must be between -360 and +360 degrees."
                 raise ValueError(msg)
             self.port.write(f"SENSe{self.slot}:LIA:DPHase {self.lia_phase_shift}")
+
+    def set_resistance_source(self) -> None:
+        """Select the partner module for the calculated resistance (R = V/I).
+
+        Only the resistance source is written. The excitation type (ETYPe) is deliberately
+        not set, because it would force the mode of this module and the shape of the source
+        module, interfering with the drivers that control them. The instrument returns NaN
+        for the resistance if the module pairing is incompatible.
+        """
+        if self.resistance_source == f"M{self.slot}":
+            msg = (
+                "The resistance source must be a different module than the measuring "
+                "VM-10 itself. Select a current-type module (e.g. BCS-10 or CM-10)."
+            )
+            raise ValueError(msg)
+        self.port.write(f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}")
 
     def set_analog_filter(self) -> None:
         """Configure the analog input filter of the VM-10 (hardware high/low pass)."""

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -81,7 +81,7 @@ class Device(EmptyDevice):
             "Ground": "GROund",
         }
 
-        # Corner frequency options for the analog input high/low pass filters
+        # Corner frequency options for the analog input high/low-pass filters
         self.cutoff_frequencies: dict[str, str] = {
             "None": "NONE",
             "10 Hz": "F10",
@@ -93,7 +93,7 @@ class Device(EmptyDevice):
             "10 kHz": "F10000",
         }
 
-        # Rolloff options for the analog input high/low pass filters
+        # Rolloff options for the analog input high/low-pass filters
         self.filter_rolloffs: dict[str, int] = {"6 dB/oct": 6, "12 dB/oct": 12}
 
         # Analog input filter optimization modes ('Reserve' in the SweepMe! LockIn GUI)
@@ -112,13 +112,15 @@ class Device(EmptyDevice):
         self.coupling: str = "DC"
         self.lia_ref: str = "S1"
         self.lia_harmonic: int = 1
-        self.lia_lowpass: bool = True  # traditional IIR low pass output filter on/off
+        self.lia_lowpass: bool = True  # traditional IIR low-pass output filter on/off
         self.lia_tc: float = 0.1  # time constant of the IIR output filter in s
         self.lia_rolloff: int = 12  # rolloff of the IIR output filter in dB/oct
         self.lia_avg_ref_cycles: int = 0  # 0 disables the FIR averaging output filter
         self.lia_phase_mode: str = "Auto"  # "Auto", "As is", or a float as string
         self.lia_phase_shift: float = 0.0
-        self.stored_phase_shift: float = 0.0  # phase read back before PRESet for 'As is'
+        self.stored_phase_shift: float = (
+            0.0  # phase read back before PRESet for 'As is'
+        )
         self.wait_time_constants: str = "Auto"
         self.wait_time: float = 0.0  # additional settle wait per point in s
         self.filter_on: bool = False
@@ -129,7 +131,9 @@ class Device(EmptyDevice):
         self.highpass_rolloff: int = 6
         self.digital_highpass: bool = True
         self.darkmode: bool = False
-        self.resistance_source: str = "S1"  # partner module for calculated AC resistance
+        self.resistance_source: str = (
+            "S1"  # partner module for calculated AC resistance
+        )
 
         # Result parameters
         self.x_lia: float = float("nan")
@@ -154,7 +158,7 @@ class Device(EmptyDevice):
             "Input": list(self.input_configurations.keys()),
             "Coupling": ["DC", "AC"],
             "Sensitivity": list(self.voltage_ranges.keys()),
-            "TimeConstant": ["0.1 (edit)", "Traditional low pass output filter OFF"],
+            "TimeConstant": ["0.1 (edit)", "Traditional low-pass output filter OFF"],
             "Slope": [
                 "6 dB/oct (output filter)",
                 "12 dB/oct (output filter)",
@@ -166,7 +170,7 @@ class Device(EmptyDevice):
             "Reserve": list(self.filter_optimizations.keys()),
         }
 
-        # The analog input high/low pass filters are only active
+        # The analog input high/low-pass filters are only active
         # if a filter optimization ('Reserve') is selected.
         reserve = parameters.get("Reserve", "")
         if reserve and self.filter_optimizations.get(reserve, ""):
@@ -183,7 +187,10 @@ class Device(EmptyDevice):
 
         gui_parameters.update(
             {
-                "Filter1": ["High pass digital filter ON", "High pass digital filter OFF"],
+                "Filter1": [
+                    "High pass digital filter ON",
+                    "High pass digital filter OFF",
+                ],
                 "Lock-In harmonic": 1,
                 "Reference phase shift in degrees": ["Auto", "As is", "0.0 (edit)"],
                 # Calculated resistance: pair this VM-10 with a current-type module.
@@ -206,15 +213,17 @@ class Device(EmptyDevice):
         self.port_string = parameters.get("Port", "")
         self.sweep_mode = parameters.get("SweepMode", "None")
         self.range = self.voltage_ranges.get(parameters.get("Sensitivity", "Auto"), 0.0)
-        self.input_config = self.input_configurations.get(parameters.get("Input", "A-B"), "AB")
+        self.input_config = self.input_configurations.get(
+            parameters.get("Input", "A-B"), "AB"
+        )
         self.coupling = parameters.get("Coupling", "DC")
         self.lia_ref = parameters.get("Source", "S1")
         self.lia_harmonic = parameters.get("Lock-In harmonic", 1)
         self.lia_avg_ref_cycles = parameters.get("Averaging reference cycles", 0)
         self.wait_time_constants = str(parameters.get("WaitTimeConstants", "Auto"))
 
-        # Traditional IIR low pass output filter: a numeric entry is the time constant,
-        # any non-numeric entry (e.g. "Traditional low pass output filter OFF") disables it.
+        # Traditional IIR low-pass output filter: a numeric entry is the time constant,
+        # any non-numeric entry (e.g. "Traditional low-pass output filter OFF") disables it.
         raw_tc = str(parameters.get("TimeConstant", "0.1"))
         try:
             self.lia_tc = float(raw_tc.split(" ")[0])
@@ -229,20 +238,28 @@ class Device(EmptyDevice):
             self.lia_rolloff = 12
 
         # Analog input filter ('Reserve' selects the filter optimization)
-        self.filter_optimization = self.filter_optimizations.get(parameters.get("Reserve", ""), "")
+        self.filter_optimization = self.filter_optimizations.get(
+            parameters.get("Reserve", ""), ""
+        )
         self.filter_on = bool(self.filter_optimization)
         if self.filter_on:
             lowpass = str(parameters.get("LowPassFilter", "None")).split(",")
-            self.lowpass_corner = self.cutoff_frequencies.get(lowpass[0].strip(), "NONE")
+            self.lowpass_corner = self.cutoff_frequencies.get(
+                lowpass[0].strip(), "NONE"
+            )
             if len(lowpass) > 1:
                 self.lowpass_rolloff = self.filter_rolloffs.get(lowpass[1].strip(), 6)
             highpass = str(parameters.get("HighPassFilter", "None")).split(",")
-            self.highpass_corner = self.cutoff_frequencies.get(highpass[0].strip(), "NONE")
+            self.highpass_corner = self.cutoff_frequencies.get(
+                highpass[0].strip(), "NONE"
+            )
             if len(highpass) > 1:
                 self.highpass_rolloff = self.filter_rolloffs.get(highpass[1].strip(), 6)
 
         self.digital_highpass = "ON" in str(parameters.get("Filter1", "ON"))
-        self.lia_phase_mode = str(parameters.get("Reference phase shift in degrees", "Auto"))
+        self.lia_phase_mode = str(
+            parameters.get("Reference phase shift in degrees", "Auto")
+        )
         self.darkmode = bool(parameters.get("Turn off LED", False))
         self.resistance_source = str(parameters.get("Resistance source", "S1"))
 
@@ -276,7 +293,9 @@ class Device(EmptyDevice):
             # PRESet below resets the reference phase shift to its power-on default.
             # Remember the phase currently set on the instrument so that
             # set_lockin_settings() can restore it afterwards.
-            self.stored_phase_shift = float(self.port.query(f"SENSe{self.slot}:LIA:DPHase?"))
+            self.stored_phase_shift = float(
+                self.port.query(f"SENSe{self.slot}:LIA:DPHase?")
+            )
         self.port.write(f"SENSe{self.slot}:PRESet")  # reset module to power-on defaults
 
     def configure(self) -> None:
@@ -293,11 +312,53 @@ class Device(EmptyDevice):
         self.set_lockin_settings()
         self.set_advanced_settings()
 
-    def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
-        """Reapply the configuration when a GUI parameter changes during a run via the {...} parameter system."""
+    def reconfigure(
+        self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None
+    ) -> None:
+        """Rewrite only the settings whose GUI parameter changed via the {...} parameter system.
+
+        Only the affected part of the configuration is written: rewriting everything would
+        resend all commands and retrigger the automatic phase adjustment on every change.
+
+        A setting that is currently being swept is skipped, because apply() owns it. SweepMe!
+        calls apply() only when the sweep value changes, so overwriting the swept value with
+        the GUI value here would persist for the rest of the branch.
+        """
         if parameters:
             self.apply_gui_parameters(parameters)
-        self.configure()
+        changed = set(keys or [])
+
+        if not changed or "Channel" in changed:
+            # Nothing specified, or the measure channel itself changed: write everything
+            self.configure()
+            return
+
+        if changed & {"Reserve", "LowPassFilter", "HighPassFilter"}:
+            self.set_analog_filter()
+            changed.add("Sensitivity")  # the available ranges depend on the filter optimization
+        if "Input" in changed:
+            self.set_input_configuration(self.input_config)
+        if "Coupling" in changed:
+            self.set_coupling(self.coupling)
+        if "Sensitivity" in changed and self.sweep_mode != "Sensitivity in V":
+            self.set_range()
+        if (
+            changed & {"TimeConstant", "Slope", "WaitTimeConstants"}
+            and self.sweep_mode != "Time constant in s"
+        ):
+            self.set_time_constant()
+        if "Resistance source" in changed:
+            self.set_resistance_source()
+            changed.add("Source")  # the resistance source overwrites the lock-in reference source
+        if changed & {
+            "Source",
+            "Lock-In harmonic",
+            "Averaging reference cycles",
+            "Reference phase shift in degrees",
+        }:
+            self.set_lockin_settings()
+        if changed & {"Filter1", "Turn off LED"}:
+            self.set_advanced_settings()
 
     def apply(self) -> None:
         """Apply a new sweep value (self.value) according to the selected sweep mode."""
@@ -332,7 +393,9 @@ class Device(EmptyDevice):
             # Additional wait of N time constants, e.g. after a source module changed its value.
             # Sleep in small steps so the user can stop the run at any time.
             start_time = time.time()
-            while not self.is_run_stopped() and time.time() - start_time < self.wait_time:
+            while (
+                not self.is_run_stopped() and time.time() - start_time < self.wait_time
+            ):
                 time.sleep(min(0.05, self.wait_time))
         self.request_lockin_snapshot()
 
@@ -372,12 +435,21 @@ class Device(EmptyDevice):
         # The instrument returns NaN if the pairing is incompatible or a module has an error.
         self.resistance_results = []
         for quantity in ("INPHase", "QUADrature", "MAGNitude", "PHASe"):
-            response = self.port.query(f"CALCulate:SENSe{self.slot}:RESistance:{quantity}?")
+            response = self.port.query(
+                f"CALCulate:SENSe{self.slot}:RESistance:{quantity}?"
+            )
             self.resistance_results.append(self.convert_measurement(response))
 
     def call(self) -> list[float]:
         """Return the measurement results in the order of self.variables."""
-        results = [self.x_lia, self.y_lia, self.r_lia, self.theta_lia, self.freq_lia, self.dc_lia]
+        results = [
+            self.x_lia,
+            self.y_lia,
+            self.r_lia,
+            self.theta_lia,
+            self.freq_lia,
+            self.dc_lia,
+        ]
         return results + self.resistance_results
 
     # --- wrapped functions ---
@@ -416,11 +488,18 @@ class Device(EmptyDevice):
                     f"The VM-10 supports 10 V, 1 V, 0.1 V, and 0.01 V."
                 )
                 raise ValueError(msg)
-            if self.filter_on and self.filter_optimization == "REServe" and self.range > 0.1:
-                # The VM-10 does not support this combination. It would quietly reduce the range.
+            if (
+                self.filter_on
+                and self.filter_optimization == "NOISe"
+                and self.range > 0.1
+            ):
+                # In 'Lowest noise' mode gain is placed before the analog filters, so the
+                # filter stage would be overdriven on the high ranges. The VM-10 does not
+                # support this combination and would quietly reduce the range.
                 msg = (
                     "The 10 V and 1 V ranges cannot be used while the analog input filter "
-                    "is enabled with filter optimization 'Highest reserve'."
+                    "is enabled with filter optimization 'Lowest noise'. "
+                    "Use 'Highest reserve' or a sensitivity of 100 mV or below."
                 )
                 raise ValueError(msg)
             self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 0")
@@ -429,19 +508,23 @@ class Device(EmptyDevice):
             self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 1")
 
     def set_time_constant(self) -> None:
-        """Configure the traditional IIR low pass output filter and the settle wait time."""
+        """Configure the traditional IIR low-pass output filter and the settle wait time."""
         # Additional wait time per measurement point in units of the time constant
         if self.wait_time_constants.strip().lower() == "auto":
             # Rely on the instrument's settling flag, no additional wait
             self.wait_time = 0.0
         else:
             try:
-                self.wait_time = float(self.wait_time_constants) * (self.lia_tc if self.lia_lowpass else 0.0)
+                self.wait_time = float(self.wait_time_constants) * (
+                    self.lia_tc if self.lia_lowpass else 0.0
+                )
             except (ValueError, TypeError) as e:
                 msg = "'WaitTimeConstants' must be 'Auto' or a number."
                 raise ValueError(msg) from e
 
-        self.port.write(f"SENSe{self.slot}:LIA:LPASs {'1' if self.lia_lowpass else '0'}")
+        self.port.write(
+            f"SENSe{self.slot}:LIA:LPASs {'1' if self.lia_lowpass else '0'}"
+        )
         if self.lia_lowpass:
             if not 0.0001 <= self.lia_tc <= 10000:
                 msg = f"Lock-In time constant is {self.lia_tc} s. Must be between 0.0001 s and 10,000 s."
@@ -531,23 +614,37 @@ class Device(EmptyDevice):
                 "VM-10 itself. Select a current-type module (e.g. BCS-10 or CM-10)."
             )
             raise ValueError(msg)
-        self.port.write(f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}")
+        self.port.write(
+            f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}"
+        )
 
     def set_analog_filter(self) -> None:
-        """Configure the analog input filter of the VM-10 (hardware high/low pass)."""
+        """Configure the analog input filter of the VM-10 (hardware high/low-pass)."""
         if not self.filter_on:
             self.port.write(f"SENSe{self.slot}:FILTer:STATe 0")
             return
         self.port.write(f"SENSe{self.slot}:FILTer:STATe 1")
-        self.port.write(f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}")
-        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}")
-        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}")
-        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}")
-        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
+        self.port.write(
+            f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}"
+        )
+        self.port.write(
+            f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}"
+        )
+        self.port.write(
+            f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}"
+        )
+        self.port.write(
+            f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}"
+        )
+        self.port.write(
+            f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}"
+        )
 
     def set_advanced_settings(self) -> None:
         """Configure the digital high pass filter and dark mode."""
-        self.port.write(f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}")
+        self.port.write(
+            f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}"
+        )
         self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
 
     def request_lockin_snapshot(self) -> None:

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -328,8 +328,8 @@ class Device(EmptyDevice):
             self.apply_gui_parameters(parameters)
         changed = set(keys or [])
 
-        if not changed or "Channel" in changed:
-            # Nothing specified, or the measure channel itself changed: write everything
+        if not changed:
+            # Nothing specified: write everything
             self.configure()
             return
 

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -118,9 +118,7 @@ class Device(EmptyDevice):
         self.lia_avg_ref_cycles: int = 0  # 0 disables the FIR averaging output filter
         self.lia_phase_mode: str = "Auto"  # "Auto", "As is", or a float as string
         self.lia_phase_shift: float = 0.0
-        self.stored_phase_shift: float = (
-            0.0  # phase read back before PRESet for 'As is'
-        )
+        self.stored_phase_shift: float = 0.0  # phase read back before PRESet for 'As is'
         self.wait_time_constants: str = "Auto"
         self.wait_time: float = 0.0  # additional settle wait per point in s
         self.filter_on: bool = False
@@ -131,9 +129,7 @@ class Device(EmptyDevice):
         self.highpass_rolloff: int = 6
         self.digital_highpass: bool = True
         self.darkmode: bool = False
-        self.resistance_source: str = (
-            "S1"  # partner module for calculated AC resistance
-        )
+        self.resistance_source: str = "S1"  # partner module for calculated AC resistance
 
         # Result parameters
         self.x_lia: float = float("nan")
@@ -213,9 +209,7 @@ class Device(EmptyDevice):
         self.port_string = parameters.get("Port", "")
         self.sweep_mode = parameters.get("SweepMode", "None")
         self.range = self.voltage_ranges.get(parameters.get("Sensitivity", "Auto"), 0.0)
-        self.input_config = self.input_configurations.get(
-            parameters.get("Input", "A-B"), "AB"
-        )
+        self.input_config = self.input_configurations.get(parameters.get("Input", "A-B"), "AB")
         self.coupling = parameters.get("Coupling", "DC")
         self.lia_ref = parameters.get("Source", "S1")
         self.lia_harmonic = parameters.get("Lock-In harmonic", 1)
@@ -238,28 +232,20 @@ class Device(EmptyDevice):
             self.lia_rolloff = 12
 
         # Analog input filter ('Reserve' selects the filter optimization)
-        self.filter_optimization = self.filter_optimizations.get(
-            parameters.get("Reserve", ""), ""
-        )
+        self.filter_optimization = self.filter_optimizations.get(parameters.get("Reserve", ""), "")
         self.filter_on = bool(self.filter_optimization)
         if self.filter_on:
             lowpass = str(parameters.get("LowPassFilter", "None")).split(",")
-            self.lowpass_corner = self.cutoff_frequencies.get(
-                lowpass[0].strip(), "NONE"
-            )
+            self.lowpass_corner = self.cutoff_frequencies.get(lowpass[0].strip(), "NONE")
             if len(lowpass) > 1:
                 self.lowpass_rolloff = self.filter_rolloffs.get(lowpass[1].strip(), 6)
             highpass = str(parameters.get("HighPassFilter", "None")).split(",")
-            self.highpass_corner = self.cutoff_frequencies.get(
-                highpass[0].strip(), "NONE"
-            )
+            self.highpass_corner = self.cutoff_frequencies.get(highpass[0].strip(), "NONE")
             if len(highpass) > 1:
                 self.highpass_rolloff = self.filter_rolloffs.get(highpass[1].strip(), 6)
 
         self.digital_highpass = "ON" in str(parameters.get("Filter1", "ON"))
-        self.lia_phase_mode = str(
-            parameters.get("Reference phase shift in degrees", "Auto")
-        )
+        self.lia_phase_mode = str(parameters.get("Reference phase shift in degrees", "Auto"))
         self.darkmode = bool(parameters.get("Turn off LED", False))
         self.resistance_source = str(parameters.get("Resistance source", "S1"))
 
@@ -293,9 +279,7 @@ class Device(EmptyDevice):
             # PRESet below resets the reference phase shift to its power-on default.
             # Remember the phase currently set on the instrument so that
             # set_lockin_settings() can restore it afterwards.
-            self.stored_phase_shift = float(
-                self.port.query(f"SENSe{self.slot}:LIA:DPHase?")
-            )
+            self.stored_phase_shift = float(self.port.query(f"SENSe{self.slot}:LIA:DPHase?"))
         self.port.write(f"SENSe{self.slot}:PRESet")  # reset module to power-on defaults
 
     def configure(self) -> None:
@@ -347,9 +331,7 @@ class Device(EmptyDevice):
             # Additional wait of N time constants, e.g. after a source module changed its value.
             # Sleep in small steps so the user can stop the run at any time.
             start_time = time.time()
-            while (
-                not self.is_run_stopped() and time.time() - start_time < self.wait_time
-            ):
+            while not self.is_run_stopped() and time.time() - start_time < self.wait_time:
                 time.sleep(min(0.05, self.wait_time))
         self.request_lockin_snapshot()
 
@@ -389,9 +371,7 @@ class Device(EmptyDevice):
         # The instrument returns NaN if the pairing is incompatible or a module has an error.
         self.resistance_results = []
         for quantity in ("INPHase", "QUADrature", "MAGNitude", "PHASe"):
-            response = self.port.query(
-                f"CALCulate:SENSe{self.slot}:RESistance:{quantity}?"
-            )
+            response = self.port.query(f"CALCulate:SENSe{self.slot}:RESistance:{quantity}?")
             self.resistance_results.append(self.convert_measurement(response))
 
     def call(self) -> list[float]:
@@ -412,10 +392,7 @@ class Device(EmptyDevice):
         """Verify that the module connected to the selected channel is a VM-10."""
         model = self.port.query(f"SENSe{self.slot}:MODel?")
         if "VM-10" not in model:
-            msg = (
-                f"Device connected on channel M{self.slot} does not match this driver. "
-                f"Found: '{model}'"
-            )
+            msg = f"Device connected on channel M{self.slot} does not match this driver. " f"Found: '{model}'"
             raise ValueError(msg)
 
     def set_mode(self, mode: str) -> None:
@@ -437,16 +414,9 @@ class Device(EmptyDevice):
         """Set the voltage range or enable autorange (self.range == 0.0)."""
         if self.range:
             if self.range not in self.voltage_ranges.values():
-                msg = (
-                    f"Invalid sensitivity '{self.range}'. "
-                    f"The VM-10 supports 10 V, 1 V, 0.1 V, and 0.01 V."
-                )
+                msg = f"Invalid sensitivity '{self.range}'. " f"The VM-10 supports 10 V, 1 V, 0.1 V, and 0.01 V."
                 raise ValueError(msg)
-            if (
-                self.filter_on
-                and self.filter_optimization == "NOISe"
-                and self.range > 0.1
-            ):
+            if self.filter_on and self.filter_optimization == "NOISe" and self.range > 0.1:
                 # In 'Lowest noise' mode gain is placed before the analog filters, so the
                 # filter stage would be overdriven on the high ranges. The VM-10 does not
                 # support this combination and would quietly reduce the range.
@@ -469,16 +439,12 @@ class Device(EmptyDevice):
             self.wait_time = 0.0
         else:
             try:
-                self.wait_time = float(self.wait_time_constants) * (
-                    self.lia_tc if self.lia_lowpass else 0.0
-                )
+                self.wait_time = float(self.wait_time_constants) * (self.lia_tc if self.lia_lowpass else 0.0)
             except (ValueError, TypeError) as e:
                 msg = "'WaitTimeConstants' must be 'Auto' or a number."
                 raise ValueError(msg) from e
 
-        self.port.write(
-            f"SENSe{self.slot}:LIA:LPASs {'1' if self.lia_lowpass else '0'}"
-        )
+        self.port.write(f"SENSe{self.slot}:LIA:LPASs {'1' if self.lia_lowpass else '0'}")
         if self.lia_lowpass:
             if not 0.0001 <= self.lia_tc <= 10000:
                 msg = f"Lock-In time constant is {self.lia_tc} s. Must be between 0.0001 s and 10,000 s."
@@ -544,10 +510,7 @@ class Device(EmptyDevice):
             try:
                 self.lia_phase_shift = float(phase_mode.split(" ")[0])
             except (ValueError, TypeError) as e:
-                msg = (
-                    "The reference phase shift must be 'Auto', 'As is', "
-                    "or a number between -360 and +360 degrees."
-                )
+                msg = "The reference phase shift must be 'Auto', 'As is', " "or a number between -360 and +360 degrees."
                 raise ValueError(msg) from e
             if not -360 <= self.lia_phase_shift <= 360:
                 msg = "The reference phase shift must be between -360 and +360 degrees."
@@ -568,9 +531,7 @@ class Device(EmptyDevice):
                 "VM-10 itself. Select a current-type module (e.g. BCS-10 or CM-10)."
             )
             raise ValueError(msg)
-        self.port.write(
-            f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}"
-        )
+        self.port.write(f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}")
 
     def set_analog_filter(self) -> None:
         """Configure the analog input filter of the VM-10 (hardware high/low-pass)."""
@@ -578,27 +539,15 @@ class Device(EmptyDevice):
             self.port.write(f"SENSe{self.slot}:FILTer:STATe 0")
             return
         self.port.write(f"SENSe{self.slot}:FILTer:STATe 1")
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}"
-        )
-        self.port.write(
-            f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}"
-        )
+        self.port.write(f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
 
     def set_advanced_settings(self) -> None:
         """Configure the digital high pass filter and dark mode."""
-        self.port.write(
-            f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}"
-        )
+        self.port.write(f"SENSe{self.slot}:DIGital:FILTer:HPASs {'1' if self.digital_highpass else '0'}")
         self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
 
     def request_lockin_snapshot(self) -> None:

--- a/src/LockIn-LakeShore_M81-VM-10/main.py
+++ b/src/LockIn-LakeShore_M81-VM-10/main.py
@@ -304,61 +304,15 @@ class Device(EmptyDevice):
         self.set_input_configuration(self.input_config)
         self.set_coupling(self.coupling)
         self.set_analog_filter()  # set filters before range: the range limits depend on them
-        self.set_range()
-        self.set_time_constant()
+        if self.sweep_mode == "Sensitivity in V":
+            self.set_range()
+        if self.sweep_mode != "Time constant in s":
+            self.set_time_constant()
         # The resistance source must be set before the lock-in settings: in lock-in mode,
         # writing the resistance source also overwrites the lock-in reference source.
         self.set_resistance_source()
         self.set_lockin_settings()
         self.set_advanced_settings()
-
-    def reconfigure(
-        self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None
-    ) -> None:
-        """Rewrite only the settings whose GUI parameter changed via the {...} parameter system.
-
-        Only the affected part of the configuration is written: rewriting everything would
-        resend all commands and retrigger the automatic phase adjustment on every change.
-
-        A setting that is currently being swept is skipped, because apply() owns it. SweepMe!
-        calls apply() only when the sweep value changes, so overwriting the swept value with
-        the GUI value here would persist for the rest of the branch.
-        """
-        if parameters:
-            self.apply_gui_parameters(parameters)
-        changed = set(keys or [])
-
-        if not changed:
-            # Nothing specified: write everything
-            self.configure()
-            return
-
-        if changed & {"Reserve", "LowPassFilter", "HighPassFilter"}:
-            self.set_analog_filter()
-            changed.add("Sensitivity")  # the available ranges depend on the filter optimization
-        if "Input" in changed:
-            self.set_input_configuration(self.input_config)
-        if "Coupling" in changed:
-            self.set_coupling(self.coupling)
-        if "Sensitivity" in changed and self.sweep_mode != "Sensitivity in V":
-            self.set_range()
-        if (
-            changed & {"TimeConstant", "Slope", "WaitTimeConstants"}
-            and self.sweep_mode != "Time constant in s"
-        ):
-            self.set_time_constant()
-        if "Resistance source" in changed:
-            self.set_resistance_source()
-            changed.add("Source")  # the resistance source overwrites the lock-in reference source
-        if changed & {
-            "Source",
-            "Lock-In harmonic",
-            "Averaging reference cycles",
-            "Reference phase shift in degrees",
-        }:
-            self.set_lockin_settings()
-        if changed & {"Filter1", "Turn off LED"}:
-            self.set_advanced_settings()
 
     def apply(self) -> None:
         """Apply a new sweep value (self.value) according to the selected sweep mode."""

--- a/src/Logger-LakeShore_M81-VM-10/doc/description.md
+++ b/src/Logger-LakeShore_M81-VM-10/doc/description.md
@@ -19,7 +19,6 @@ The averaging time is set in number of power line cycles (NPLC, 0.01 to 600). Th
 
 - Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
 - Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
-- "Frequency range threshold factor" (0.0–1.0): during autorange with AC signals, a range is chosen such that the signal frequency does not exceed this fraction of the range's -3 dB bandwidth.
 
 ## Input configuration and coupling
 

--- a/src/Logger-LakeShore_M81-VM-10/doc/description.md
+++ b/src/Logger-LakeShore_M81-VM-10/doc/description.md
@@ -1,6 +1,38 @@
-# VM-10 module of LakeShore M81:
-- Log voltage using the VM-10 module of the LakeShore M81 Synchronous Source Measurement System.
-- Three physical measurement channels (M1, M2 and M3) are available at the M81. Connect your VM-10 module to one of them.
-- Select the corresponding channel number in SweepMe!
-- The driver supports DC and AC measurements. Lock-in mode is not yet supported.
-- Advanced settings like coupling or low pass filters are not yet supported. 
+# Logger driver for the VM-10 module of the LakeShore M81-SSM
+
+- Logs DC and AC voltages using the VM-10 voltage measure module of the LakeShore M81 Synchronous Source Measure System.
+- Three physical measure channels (M1, M2, M3) are available on the M81. Connect your VM-10 module to one of them and select the corresponding channel in SweepMe!.
+- For phase-sensitive detection at a reference frequency, use the LockIn driver "LockIn-LakeShore_M81-VM-10" instead.
+
+## Modes and returned variables
+
+- **DC mode**: returns **Voltage DC** in V, averaged over the configured averaging time.
+- **AC mode**: returns **Voltage RMS** (total RMS including AC and DC components within the observation window) and **Voltage DC**, both in V. With "Include peak values" enabled, it additionally returns **Voltage Positive Peak**, **Voltage Negative Peak**, and **Voltage Peak-Peak**. All values of one measurement point stem from a single, time-synchronized acquisition.
+
+Special values: **+inf** indicates a range overload, **NaN** indicates that the value is invalid or still settling. Choose a larger range (or Auto) on overload.
+
+## Averaging time
+
+The averaging time is set in number of power line cycles (NPLC, 0.01 to 600). The M81 detects the line frequency automatically. For the best rejection of line-related interference, use an integer number of NPLC. Each measurement point waits for settling plus the averaging time, so large NPLC values slow down the acquisition accordingly.
+
+## Range
+
+- Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
+- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
+- "Frequency range threshold factor" (0.0–1.0): during autorange with AC signals, a range is chosen such that the signal frequency does not exceed this fraction of the range's -3 dB bandwidth.
+
+## Input configuration and coupling
+
+- **Input configuration**: "A-B" (differential), "A" (single-ended vs. measure ground), or "Ground" (input internally grounded, e.g. for offset checks).
+- **Coupling**: DC or AC. AC coupling engages a 0.16 Hz high pass and blocks DC signals; the driver therefore rejects AC coupling in DC mode. Note that with AC coupling the input bias current causes a small DC offset.
+
+## Analog input filter
+
+The VM-10 contains hardware high pass and low pass filters (corner frequencies 10 Hz to 10 kHz, 6 or 12 dB/oct) in front of the amplifier chain, useful for rejecting large interfering signals:
+
+- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads.
+- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise (10 V and 1 V ranges unavailable).
+
+The high pass filter is only offered in AC mode, since it would remove the DC component in DC mode.
+
+Note: the datasheet also lists 30 kHz corner frequencies, but the remote interface manual only documents corner frequencies up to 10 kHz, so this driver offers up to 10 kHz.

--- a/src/Logger-LakeShore_M81-VM-10/doc/description.md
+++ b/src/Logger-LakeShore_M81-VM-10/doc/description.md
@@ -6,10 +6,16 @@
 
 ## Modes and returned variables
 
-- **DC mode**: returns **Voltage DC** in V, averaged over the configured averaging time.
+- **DC mode**: returns **Voltage DC** in V, averaged over the configured averaging time, and **Resistance** in Ohm (see "Calculated resistance" below).
 - **AC mode**: returns **Voltage RMS** (total RMS including AC and DC components within the observation window) and **Voltage DC**, both in V. With "Include peak values" enabled, it additionally returns **Voltage Positive Peak**, **Voltage Negative Peak**, and **Voltage Peak-Peak**. All values of one measurement point stem from a single, time-synchronized acquisition.
 
 Special values: **+inf** indicates a range overload, **NaN** indicates that the value is invalid or still settling. Choose a larger range (or Auto) on overload.
+
+## Calculated resistance ("Resistance source", DC mode only)
+
+The M81 calculates a DC resistance by pairing this VM-10 with a current-type module: select the module that drives or measures the current through your sample (e.g. a BCS-10 source or a CM-10 measure module) as "Resistance source" (default: S1, matching the instrument default). In DC mode the driver always returns **Resistance** in Ohm, calculated by the instrument from time-synchronized readings. The value is NaN when the pairing is incompatible (e.g. another voltage module), a paired module reports an error, or the source amplitude is 0 — in that case simply ignore the column. AC excitation resistance requires lock-in mode and is available in the LockIn driver.
+
+The driver intentionally does not touch the instrument's resistance excitation type or optimization settings, since these would reconfigure the source module behind the back of the driver controlling it.
 
 ## Averaging time
 

--- a/src/Logger-LakeShore_M81-VM-10/doc/description.md
+++ b/src/Logger-LakeShore_M81-VM-10/doc/description.md
@@ -24,7 +24,7 @@ The averaging time is set in number of power line cycles (NPLC, 0.01 to 600). Th
 ## Range
 
 - Ranges: 10 V, 1 V, 100 mV, 10 mV, or Auto. The lowest usable range gives the best performance. The VM-10 features seamless range transitions.
-- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Highest reserve". The driver raises an error for this combination.
+- Restriction: the 10 V and 1 V ranges are not available while the analog input filter is enabled with optimization "Lowest noise". The driver raises an error for this combination.
 
 ## Input configuration and coupling
 
@@ -35,8 +35,8 @@ The averaging time is set in number of power line cycles (NPLC, 0.01 to 600). Th
 
 The VM-10 contains hardware high pass and low pass filters (corner frequencies 10 Hz to 10 kHz, 6 or 12 dB/oct) in front of the amplifier chain, useful for rejecting large interfering signals:
 
-- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads.
-- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise (10 V and 1 V ranges unavailable).
+- **Lowest noise**: gain before the filters; best noise, but large interferers can cause overloads (10 V and 1 V ranges unavailable).
+- **Highest reserve**: all gain after the filters; tolerates the largest interference at the cost of higher noise.
 
 The high pass filter is only offered in AC mode, since it would remove the DC component in DC mode.
 

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -113,6 +113,7 @@ class Device(EmptyDevice):
         self.input_config: str = "AB"
         self.coupling: str = "DC"
         self.include_peaks: bool = False
+        self.resistance_source: str = "S1"  # partner module for calculated resistance (DC mode)
         self.filter_on: bool = False
         self.filter_optimization: str = "NOISe"
         self.lowpass_corner: str = "NONE"
@@ -140,6 +141,11 @@ class Device(EmptyDevice):
         if mode == "AC":
             # Peak detection is only meaningful for AC signals
             gui_parameters["Include peak values"] = False
+        else:
+            # Calculated resistance: pair this VM-10 with a current-type module.
+            # DC excitation requires DC measure mode, so it is only offered here.
+            # The instrument always has a resistance source selected (default S1).
+            gui_parameters["Resistance source"] = ["S1", "S2", "S3", "M1", "M2", "M3"]
 
         gui_parameters[" "] = None  # empty line
         gui_parameters["Analog input filter"] = False
@@ -172,6 +178,8 @@ class Device(EmptyDevice):
         )
         self.coupling = parameters.get("Coupling", "DC")
         self.include_peaks = bool(parameters.get("Include peak values", False))
+        # Calculated DC resistance is only available in DC mode
+        self.resistance_source = str(parameters.get("Resistance source", "S1"))
 
         try:
             self.nplc = float(parameters.get("Averaging time (NPLC)", 1.0))
@@ -211,8 +219,8 @@ class Device(EmptyDevice):
                 self.variables += ["Voltage Positive Peak", "Voltage Negative Peak", "Voltage Peak-Peak"]
                 self.units += ["V", "V", "V"]
         else:
-            self.variables = ["Voltage DC"]
-            self.units = ["V"]
+            self.variables = ["Voltage DC", "Resistance"]
+            self.units = ["V", "Ohm"]
         self.plottype = [True] * len(self.variables)
         self.savetype = [True] * len(self.variables)
 
@@ -234,6 +242,7 @@ class Device(EmptyDevice):
         self.set_analog_filter()  # set filters before range: the range limits depend on them
         self.set_range()
         self.set_nplc(self.nplc)
+        self.set_resistance_source()
         self.set_advanced_settings()
 
     def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
@@ -255,14 +264,22 @@ class Device(EmptyDevice):
 
     def read_result(self) -> None:
         """Read the acquired values from the instrument."""
+        # The calculated resistance is queried separately and is not part of the READ response
+        expected = len(self.variables) - (1 if self.mode == "DC" else 0)
         response = self.port.read().split(",")
-        if len(response) != len(self.variables):
+        if len(response) != expected:
             msg = (
-                f"Unexpected response length: expected {len(self.variables)} values, "
+                f"Unexpected response length: expected {expected} values, "
                 f"received {len(response)}: '{','.join(response)}'"
             )
             raise ValueError(msg)
         self.results = [self.convert_measurement(value) for value in response]
+
+        if self.mode == "DC":
+            # Calculated DC resistance from this module and the selected resistance source.
+            # Returns NaN if the pairing is incompatible or a module reports an error.
+            resistance = self.port.query(f"CALCulate:SENSe{self.slot}:RESistance:DC?")
+            self.results.append(self.convert_measurement(resistance))
 
     def call(self) -> list[float]:
         """Return the measurement results in the order of self.variables."""
@@ -336,6 +353,24 @@ class Device(EmptyDevice):
         self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}")
         if self.highpass_corner != "NONE":
             self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
+
+    def set_resistance_source(self) -> None:
+        """Select the partner module for the calculated resistance (R = V/I).
+
+        Only the resistance source is written. The excitation type (ETYPe) is deliberately
+        not set, because it would force the mode of this module and the shape of the source
+        module, interfering with the drivers that control them. The instrument returns NaN
+        for the resistance if the module pairing is incompatible.
+        """
+        if self.mode != "DC":
+            return  # calculated DC resistance is only used in DC mode
+        if self.resistance_source == f"M{self.slot}":
+            msg = (
+                "The resistance source must be a different module than the measuring "
+                "VM-10 itself. Select a current-type module (e.g. BCS-10 or CM-10)."
+            )
+            raise ValueError(msg)
+        self.port.write(f"CALCulate:SENSe{self.slot}:RESistance:SOURce {self.resistance_source}")
 
     def set_advanced_settings(self) -> None:
         """Configure the dark mode of the module LEDs."""

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -5,7 +5,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2025 SweepMe! GmbH (sweep-me.net)
+# Copyright (c) 2026 SweepMe! GmbH (sweep-me.net)
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,163 +29,348 @@
 # * Module: Logger
 # * Instrument: LakeShore M81 VM-10
 
+from __future__ import annotations
 
-from pysweepme.EmptyDeviceClass import EmptyDevice
+from typing import Any
+
+from pysweepme.EmptyDeviceClass import EmptyDevice  # Class comes with SweepMe!
+
 
 class Device(EmptyDevice):
-    def __init__(self):
+    """SweepMe! Logger driver for the VM-10 voltage measure module of the LakeShore M81-SSM.
+
+    Supports DC and AC (RMS/peak) voltage measurements. For phase-sensitive detection
+    at a reference frequency, use the LockIn driver "LockIn-LakeShore_M81-VM-10" instead.
+    """
+
+    def __init__(self) -> None:
+        """Initialize driver parameters and option-to-command dictionaries."""
         EmptyDevice.__init__(self)
 
+        self.shortname = "M81 VM-10"
+
         self.port_manager = True
-           
         self.port_types = ["COM", "GPIB", "TCPIP", "SOCKET"]
-        
+
         self.port_properties = {
-                                "baudrate": 921600,
-                                "EOL": "\n",
-                                "timeout": 15,
-                                "TCPIP_EOLwrite": "\n",
-                                "TCPIP_EOLread": "\n",
-                                "SOCKET_EOLwrite": "\n",
-                                "SOCKET_EOLread": "\n",
-                                }
-
-        self.modes = {  # Possible measurement modes
-            "DC": "DC",
-            "AC": "RMS",
-            #,"Lock-In": "LIA"  Not yet implemented by SweepMe!
+            "baudrate": 921600,  # fixed baud rate of the M81 USB serial interface
+            "EOL": "\n",
+            # READ queries block until settling + averaging time are finished.
+            # The maximum averaging time is 600 NPLC = 12 s at 50 Hz.
+            "timeout": 30,
+            "TCPIP_EOLwrite": "\n",
+            "TCPIP_EOLread": "\n",
+            "SOCKET_EOLwrite": "\n",
+            "SOCKET_EOLread": "\n",
         }
 
-        self.range_limits = {  # Voltage range limits in V
-            "10 mV (7.07 mV RMS)" : 0.01,
-            "100 mV (70.7 mV RMS)": 0.1,
-            "1 V (707 mV RMS)": 1,
-            "10 V (7.07 V RMS)": 10
+        # Measurement modes of the VM-10 supported by this Logger driver
+        self.modes: list[str] = ["DC", "AC"]
+
+        # Voltage ranges of the VM-10 in V; 0.0 stands for autorange
+        self.voltage_ranges: dict[str, float] = {
+            "Auto": 0.0,
+            "10 V": 10.0,
+            "1 V": 1.0,
+            "100 mV": 0.1,
+            "10 mV": 0.01,
         }
 
-        self.input_configurations = {  # Possible input configurations
+        # Input configurations of the VM-10
+        self.input_configurations: dict[str, str] = {
             "A-B": "AB",
             "A": "A",
-            "Ground": "GROund"
+            "Ground": "GROund",
         }
 
-        # Measurement Parameters with default values
-        self.slot: str = ""
-        self.port_string: str = ""
-        self.nplc: float = 3  # Averaging time in Number of Power-Line-Cycles (i.e. 1/50 s)
-        self.mode_set: str = "DC"  # Direct or alternating current setting
-        self.mode_read: str = "DC"  # Read command depending on mode_set
-        self.range_mode: str = "Auto"  # Automatic or manual setting of the range
-        self.limit: float = 0.1  # Manual range limit setting
-        self.input_config: str = "AB"  # Relation of the two inputs. See touch panel for explanation.
-        self.voltage: float = float('nan')  # Measured datapoints
-            
-    def update_gui_parameters(self, parameters):
-        """Returns a dictionary with keys and values to generate GUI elements in the SweepMe! GUI."""
-        gui_parameters = {"Channel": ["M1", "M2", "M3"],  # physical channels of the M81 System
-                        "Mode": list(self.modes.keys()),
-                        "Range mode": ["Auto", "Manual"],  # Automatically set the range?
+        # Corner frequency options for the analog input high/low pass filters
+        self.cutoff_frequencies: dict[str, str] = {
+            "None": "NONE",
+            "10 Hz": "F10",
+            "30 Hz": "F30",
+            "100 Hz": "F100",
+            "300 Hz": "F300",
+            "1 kHz": "F1000",
+            "3 kHz": "F3000",
+            "10 kHz": "F10000",
         }
-        meas_range = parameters.get("Range mode")
-        if meas_range:  # Safeguard to avoid KeyError during startup, when gui parameters are being loaded
-            if meas_range == "Manual":  # Ask for manual range, only if "Manual" is selected
-                gui_parameters["Manual range limit"] = list(self.range_limits.keys())  # Selection for manual range
-        gui_parameters["Averaging time (NPLC)"] = 0.1
-        gui_parameters["Input configuration"] = list(self.input_configurations.keys())
+
+        # Rolloff options for the analog input high/low pass filters
+        self.filter_rolloffs: dict[str, int] = {"6 dB/oct": 6, "12 dB/oct": 12}
+
+        # Analog input filter optimization modes
+        self.filter_optimizations: dict[str, str] = {
+            "Lowest noise": "NOISe",
+            "Highest reserve": "REServe",
+        }
+
+        # Measurement parameters set via the GUI
+        self.slot: str = ""  # measure channel number "1", "2", or "3"
+        self.port_string: str = ""
+        self.mode: str = "DC"
+        self.range: float = 0.0  # 0.0 = autorange
+        self.nplc: float = 1.0  # averaging time in number of power line cycles
+        self.input_config: str = "AB"
+        self.coupling: str = "DC"
+        self.include_peaks: bool = False
+        self.filter_on: bool = False
+        self.filter_optimization: str = "NOISe"
+        self.lowpass_corner: str = "NONE"
+        self.lowpass_rolloff: int = 6
+        self.highpass_corner: str = "NONE"
+        self.highpass_rolloff: int = 6
+        self.freq_range_threshold: float = 0.1
+        self.darkmode: bool = False
+
+        # Result parameters
+        self.results: list[float] = []
+
+    def update_gui_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Return a dictionary of GUI fields and defaults depending on the current parameters."""
+        mode = parameters.get("Mode", "DC")
+
+        gui_parameters: dict[str, Any] = {
+            "Channel": ["M1", "M2", "M3"],  # physical measure channels of the M81
+            "Mode": self.modes,
+            "Range": list(self.voltage_ranges.keys()),
+            "Averaging time (NPLC)": 1.0,
+            "Input configuration": list(self.input_configurations.keys()),
+            "Coupling": ["DC", "AC"],
+        }
+
+        if mode == "AC":
+            # Peak detection is only meaningful for AC signals
+            gui_parameters["Include peak values"] = False
+
+        gui_parameters[" "] = None  # empty line
+        gui_parameters["Analog input filter"] = False
+        if parameters.get("Analog input filter"):
+            gui_parameters["Filter optimization"] = list(self.filter_optimizations.keys())
+            gui_parameters["Low pass corner frequency"] = list(self.cutoff_frequencies.keys())
+            gui_parameters["Low pass rolloff"] = list(self.filter_rolloffs.keys())
+            if mode == "AC":
+                # A hardware high pass would remove the DC component and falsify DC readings
+                gui_parameters["High pass corner frequency"] = list(self.cutoff_frequencies.keys())
+                gui_parameters["High pass rolloff"] = list(self.filter_rolloffs.keys())
+
+        gui_parameters["  "] = None  # empty line
+        gui_parameters["Frequency range threshold factor of -3 dB"] = 0.1
+        gui_parameters["Turn off LED"] = False
         return gui_parameters
 
+    def apply_gui_parameters(self, parameters: dict[str, Any]) -> None:
+        """Read the GUI parameters selected by the user and store them in driver attributes."""
+        channel = str(parameters.get("Channel", ""))
+        if channel.strip().lower() in ("m1", "m2", "m3"):
+            self.slot = channel.strip()[1]  # e.g. "1" for "M1"
+        else:
+            self.slot = ""
 
-    def apply_gui_parameters(self, parameter):
-        channel = parameter["Channel"]
-        if len(channel) == 2:
-            self.slot = channel[1] 
-
-        self.port_string = parameter["Port"] # use this string to open the right port object later during 'connect'
-        self.mode_set = parameter["Mode"]
-        self.mode_read = self.modes.get(self.mode_set, "")
-        self.range_mode = parameter["Range mode"]
-        if parameter.get("Manual range limit"):
-            self.limit = self.range_limits.get(parameter["Manual range limit"], 0.0)
-        self.input_config = self.input_configurations.get(parameter["Input configuration"], "")
-
+        self.port_string = parameters.get("Port", "")
+        self.mode = parameters.get("Mode", "DC")
+        self.range = self.voltage_ranges.get(parameters.get("Range", "Auto"), 0.0)
+        self.input_config = self.input_configurations.get(
+            parameters.get("Input configuration", "A-B"), "AB"
+        )
+        self.coupling = parameters.get("Coupling", "DC")
+        self.include_peaks = bool(parameters.get("Include peak values", False))
 
         try:
-            self.nplc = float(parameter["Averaging time (NPLC)"])
-        except ValueError:  # Do not fail, if parameter is not yet loaded or empty
-            self.nplc = 0.1
+            self.nplc = float(parameters.get("Averaging time (NPLC)", 1.0))
+        except (ValueError, TypeError):
+            self.nplc = 1.0  # do not fail if the parameter is not yet loaded or empty
 
-        self.shortname = "VM-10 @ M" + self.slot  # short name will be shown in the sequencer
+        self.filter_on = bool(parameters.get("Analog input filter", False))
+        if self.filter_on:
+            self.filter_optimization = self.filter_optimizations.get(
+                parameters.get("Filter optimization", "Lowest noise"), "NOISe"
+            )
+            self.lowpass_corner = self.cutoff_frequencies.get(
+                parameters.get("Low pass corner frequency", "None"), "NONE"
+            )
+            self.lowpass_rolloff = self.filter_rolloffs.get(
+                parameters.get("Low pass rolloff", "6 dB/oct"), 6
+            )
+            if self.mode == "AC":
+                self.highpass_corner = self.cutoff_frequencies.get(
+                    parameters.get("High pass corner frequency", "None"), "NONE"
+                )
+                self.highpass_rolloff = self.filter_rolloffs.get(
+                    parameters.get("High pass rolloff", "6 dB/oct"), 6
+                )
+            else:
+                self.highpass_corner = "NONE"
 
-        self.variables = ["Voltage " + self.mode_read] # Voltage DC or Voltage RMS, depending on mode
-        self.units = ["V"] # make sure that you have as many units as you have variables
-        self.plottype = [True]   # True to plot data, corresponding to self.variables
-        self.savetype = [True]   # True to save data, corresponding to self.variables
+        self.freq_range_threshold = parameters.get("Frequency range threshold factor of -3 dB", 0.1)
+        self.darkmode = bool(parameters.get("Turn off LED", False))
 
-    """ here, semantic standard functions start that are called by SweepMe! during a measurement """
-        
-    def connect(self):
-        pass
+        self.shortname = f"VM-10 @ M{self.slot}"
 
-    def disconnect(self):
-        pass
-
-    def initialize(self):
-        self.check_device()
-        self.port.write(f'SENSe{self.slot}:PRESet')  # Load power-on defaults
-    
-    def deinitialize(self):
-        # called only once at the end of the measurement
-        pass
-
-    """ the following functions are called if a new branch is entered
-     and the module was not part of the previous branch """
-
-    def configure(self):
-        self.set_mode(self.mode_set)
-        self.set_range(self.limit)
-        self.set_nplc(self.nplc)
-        self.set_input_config(self.input_config)
-
-    """ the following functions are called for each measurement point """
-
-    def measure(self):
-        self.port.write(f"READ:SENS{self.slot}:{self.mode_read}?")
-        
-    def read_result(self):
-        
-        res = self.port.read()
-        self.voltage = float(res)
-
-    def call(self):
-        return [self.voltage]
-
-    """ wrapped functions """
-
-    def set_mode(self, mode):
-        self.port.write(f'SENSe{self.slot}:MODE {mode}')
-
-    def set_range(self, limit):
-        # Set range during initialize
-        if self.range_mode == "Manual":
-            self.port.write(f'SENSe{self.slot}:VOLTage:RANGe:AUTO 0')  # Manual ranging
-            self.port.write(f'SENSe{self.slot}:VOLTage:RANGe {limit}')
+        # Returned variables depend on the mode
+        if self.mode == "AC":
+            self.variables = ["Voltage RMS", "Voltage DC"]
+            self.units = ["V", "V"]
+            if self.include_peaks:
+                self.variables += ["Voltage Positive Peak", "Voltage Negative Peak", "Voltage Peak-Peak"]
+                self.units += ["V", "V", "V"]
         else:
-            self.port.write(f'SENSe{self.slot}:VOLTage:RANGe:AUTO 1')  # Auto ranging
+            self.variables = ["Voltage DC"]
+            self.units = ["V"]
+        self.plottype = [True] * len(self.variables)
+        self.savetype = [True] * len(self.variables)
 
-    def set_nplc(self, nplc):
-        #Set averaging time during initialize
-        if not (600 >= nplc >= 0.01):
-            raise ValueError("NPLC must be between 0.01 and 600.00.")
-        self.port.write(f'SENSe{self.slot}:NPLCycles {nplc}')
+    # --- semantic standard functions called by SweepMe! during a measurement ---
 
-    def set_input_config(self, input_config):  # Set input configuration during initialize
-        self.port.write(f'SENSe{self.slot}:CONFiguration {input_config}')
+    def initialize(self) -> None:
+        """Check channel selection and connected module, then load the module defaults."""
+        if not self.slot:
+            msg = "Please give a correct channel number (M1, M2 or M3)."
+            raise ValueError(msg)
+        self.check_device()
+        self.port.write(f"SENSe{self.slot}:PRESet")  # reset module to power-on defaults
 
-    def check_device(self):
-        # Check, if connected device is actually a VM-10 module:
-        model = self.port.query(f'SENSe{self.slot}:MODel?')
-        if 'VM-10' not in model:
-            raise ValueError(
+    def configure(self) -> None:
+        """Write all GUI settings to the instrument."""
+        self.set_mode(self.mode)
+        self.set_input_configuration(self.input_config)
+        self.set_coupling(self.coupling)
+        self.set_analog_filter()  # set filters before range: the range limits depend on them
+        self.set_range()
+        self.set_nplc(self.nplc)
+        self.set_advanced_settings()
+
+    def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
+        """Reapply the configuration when a GUI parameter changes during a run via the {...} parameter system."""
+        if parameters:
+            self.apply_gui_parameters(parameters)
+        self.configure()
+
+    def measure(self) -> None:
+        """Trigger a new reading; the query returns after settling and the averaging time (NPLC)."""
+        if self.mode == "AC":
+            specifiers = f"MRMS,{self.slot},MDC,{self.slot}"
+            if self.include_peaks:
+                specifiers += f",MPPeak,{self.slot},MNPeak,{self.slot},MPTPeak,{self.slot}"
+            # READ? acquires a fresh, time-synchronized reading of all requested values
+            self.port.write(f"READ? {specifiers}")
+        else:
+            self.port.write(f"READ:SENSe{self.slot}:DC?")
+
+    def read_result(self) -> None:
+        """Read the acquired values from the instrument."""
+        response = self.port.read().split(",")
+        if len(response) != len(self.variables):
+            msg = (
+                f"Unexpected response length: expected {len(self.variables)} values, "
+                f"received {len(response)}: '{','.join(response)}'"
+            )
+            raise ValueError(msg)
+        self.results = [self.convert_measurement(value) for value in response]
+
+    def call(self) -> list[float]:
+        """Return the measurement results in the order of self.variables."""
+        return self.results
+
+    # --- wrapped functions ---
+
+    def check_device(self) -> None:
+        """Verify that the module connected to the selected channel is a VM-10."""
+        model = self.port.query(f"SENSe{self.slot}:MODel?")
+        if "VM-10" not in model:
+            msg = (
                 f"Device connected on channel M{self.slot} does not match this driver. "
-                f"Found: '{model}'")
+                f"Found: '{model}'"
+            )
+            raise ValueError(msg)
 
+    def set_mode(self, mode: str) -> None:
+        """Set the measurement mode of the module (DC or AC)."""
+        if mode not in self.modes:
+            msg = f"Invalid mode '{mode}'. This driver supports: {', '.join(self.modes)}."
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:MODE {mode}")
+
+    def set_input_configuration(self, input_config: str) -> None:
+        """Set the input configuration (AB, A, or GROund)."""
+        self.port.write(f"SENSe{self.slot}:CONFiguration {input_config}")
+
+    def set_coupling(self, coupling: str) -> None:
+        """Set the input coupling (DC or AC)."""
+        if coupling not in ("DC", "AC"):
+            msg = f"Invalid coupling '{coupling}'. Use 'DC' or 'AC'."
+            raise ValueError(msg)
+        if coupling == "AC" and self.mode == "DC":
+            # AC coupling engages a 0.16 Hz high pass that blocks the DC component
+            msg = "AC coupling cannot be used in DC mode as it blocks the DC signal."
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:COUPling {coupling}")
+
+    def set_range(self) -> None:
+        """Set the voltage range or enable autorange (self.range == 0.0)."""
+        if self.range:
+            if self.filter_on and self.filter_optimization == "REServe" and self.range > 0.1:
+                # The VM-10 does not support this combination. It would quietly reduce the range.
+                msg = (
+                    "The 10 V and 1 V ranges cannot be used while the analog input filter "
+                    "is enabled with filter optimization 'Highest reserve'."
+                )
+                raise ValueError(msg)
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 0")
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe {self.range}")
+        else:
+            self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 1")
+
+    def set_nplc(self, nplc: float) -> None:
+        """Set the averaging time in number of power line cycles (0.01 to 600)."""
+        if not 0.01 <= nplc <= 600:
+            msg = "The averaging time (NPLC) must be between 0.01 and 600.00."
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:NPLCycles {nplc}")
+
+    def set_analog_filter(self) -> None:
+        """Configure the analog input filter of the VM-10 (hardware high/low pass)."""
+        if not self.filter_on:
+            self.port.write(f"SENSe{self.slot}:FILTer:STATe 0")
+            return
+        self.port.write(f"SENSe{self.slot}:FILTer:STATe 1")
+        self.port.write(f"SENSe{self.slot}:FILTer:OPTimization {self.filter_optimization}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:FREQuency {self.lowpass_corner}")
+        self.port.write(f"SENSe{self.slot}:FILTer:LPASs:ATTenuation R{self.lowpass_rolloff}")
+        self.port.write(f"SENSe{self.slot}:FILTer:HPASs:FREQuency {self.highpass_corner}")
+        if self.highpass_corner != "NONE":
+            self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
+
+    def set_advanced_settings(self) -> None:
+        """Configure the autorange frequency threshold and dark mode."""
+        try:
+            threshold = float(self.freq_range_threshold)
+        except (ValueError, TypeError) as e:
+            msg = "Please enter a number for the frequency range threshold."
+            raise ValueError(msg) from e
+        if not 0.0 <= threshold <= 1.0:
+            msg = (
+                "The frequency range threshold must be between 0.0 and 1.0. "
+                "It is normalized to the -3 dB bandwidth of the range."
+            )
+            raise ValueError(msg)
+        self.port.write(f"SENSe{self.slot}:FRTHreshold {threshold}")
+
+        self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
+
+    @staticmethod
+    def convert_measurement(value_string: str) -> float:
+        """Convert an M81 reading to float, mapping the SCPI sentinel values.
+
+        The M81 uses two special values:
+        * 9.90e37 -> measurement overload -> converted to +inf
+        * 9.91e37 -> value invalid/settling -> converted to NaN
+        """
+        try:
+            value = float(value_string)
+        except (ValueError, TypeError):
+            return float("nan")
+        if value == 9.90e37:
+            return float("inf")
+        if value == 9.91e37:
+            return float("nan")
+        return value

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -119,7 +119,6 @@ class Device(EmptyDevice):
         self.lowpass_rolloff: int = 6
         self.highpass_corner: str = "NONE"
         self.highpass_rolloff: int = 6
-        self.freq_range_threshold: float = 0.1
         self.darkmode: bool = False
 
         # Result parameters
@@ -154,7 +153,6 @@ class Device(EmptyDevice):
                 gui_parameters["High pass rolloff"] = list(self.filter_rolloffs.keys())
 
         gui_parameters["  "] = None  # empty line
-        gui_parameters["Frequency range threshold factor of -3 dB"] = 0.1
         gui_parameters["Turn off LED"] = False
         return gui_parameters
 
@@ -201,7 +199,6 @@ class Device(EmptyDevice):
             else:
                 self.highpass_corner = "NONE"
 
-        self.freq_range_threshold = parameters.get("Frequency range threshold factor of -3 dB", 0.1)
         self.darkmode = bool(parameters.get("Turn off LED", False))
 
         self.shortname = f"VM-10 @ M{self.slot}"
@@ -341,20 +338,7 @@ class Device(EmptyDevice):
             self.port.write(f"SENSe{self.slot}:FILTer:HPASs:ATTenuation R{self.highpass_rolloff}")
 
     def set_advanced_settings(self) -> None:
-        """Configure the autorange frequency threshold and dark mode."""
-        try:
-            threshold = float(self.freq_range_threshold)
-        except (ValueError, TypeError) as e:
-            msg = "Please enter a number for the frequency range threshold."
-            raise ValueError(msg) from e
-        if not 0.0 <= threshold <= 1.0:
-            msg = (
-                "The frequency range threshold must be between 0.0 and 1.0. "
-                "It is normalized to the -3 dB bandwidth of the range."
-            )
-            raise ValueError(msg)
-        self.port.write(f"SENSe{self.slot}:FRTHreshold {threshold}")
-
+        """Configure the dark mode of the module LEDs."""
         self.port.write(f"SENSe{self.slot}:DMODe {'1' if self.darkmode else '0'}")
 
     @staticmethod

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -246,10 +246,42 @@ class Device(EmptyDevice):
         self.set_advanced_settings()
 
     def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
-        """Reapply the configuration when a GUI parameter changes during a run via the {...} parameter system."""
+        """Rewrite only the settings whose GUI parameter changed via the {...} parameter system.
+
+        Only the affected part of the configuration is written instead of resending every
+        command. Changes that alter the measure channel or the returned variables cannot be
+        handled selectively and fall back to a complete configuration.
+        """
         if parameters:
             self.apply_gui_parameters(parameters)
-        self.configure()
+        changed = set(keys or [])
+
+        if not changed or changed & {"Channel", "Mode", "Include peak values"}:
+            self.configure()
+            return
+
+        if changed & {
+            "Analog input filter",
+            "Filter optimization",
+            "Low pass corner frequency",
+            "Low pass rolloff",
+            "High pass corner frequency",
+            "High pass rolloff",
+        }:
+            self.set_analog_filter()
+            changed.add("Range")  # the available ranges depend on the filter optimization
+        if "Input configuration" in changed:
+            self.set_input_configuration(self.input_config)
+        if "Coupling" in changed:
+            self.set_coupling(self.coupling)
+        if "Range" in changed:
+            self.set_range()
+        if "Averaging time (NPLC)" in changed:
+            self.set_nplc(self.nplc)
+        if "Resistance source" in changed:
+            self.set_resistance_source()
+        if "Turn off LED" in changed:
+            self.set_advanced_settings()
 
     def measure(self) -> None:
         """Trigger a new reading; the query returns after settling and the averaging time (NPLC)."""
@@ -322,11 +354,14 @@ class Device(EmptyDevice):
     def set_range(self) -> None:
         """Set the voltage range or enable autorange (self.range == 0.0)."""
         if self.range:
-            if self.filter_on and self.filter_optimization == "REServe" and self.range > 0.1:
-                # The VM-10 does not support this combination. It would quietly reduce the range.
+            if self.filter_on and self.filter_optimization == "NOISe" and self.range > 0.1:
+                # In 'Lowest noise' mode gain is placed before the analog filters, so the
+                # filter stage would be overdriven on the high ranges. The VM-10 does not
+                # support this combination and would quietly reduce the range.
                 msg = (
                     "The 10 V and 1 V ranges cannot be used while the analog input filter "
-                    "is enabled with filter optimization 'Highest reserve'."
+                    "is enabled with filter optimization 'Lowest noise'. "
+                    "Use 'Highest reserve' or a range of 100 mV or below."
                 )
                 raise ValueError(msg)
             self.port.write(f"SENSe{self.slot}:VOLTage:RANGe:AUTO 0")

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -245,44 +245,6 @@ class Device(EmptyDevice):
         self.set_resistance_source()
         self.set_advanced_settings()
 
-    def reconfigure(self, parameters: dict[str, Any] | None = None, keys: list[str] | None = None) -> None:
-        """Rewrite only the settings whose GUI parameter changed via the {...} parameter system.
-
-        Only the affected part of the configuration is written instead of resending every
-        command. Changes that alter the measure channel or the returned variables cannot be
-        handled selectively and fall back to a complete configuration.
-        """
-        if parameters:
-            self.apply_gui_parameters(parameters)
-        changed = set(keys or [])
-
-        if not changed or changed & {"Channel", "Mode", "Include peak values"}:
-            self.configure()
-            return
-
-        if changed & {
-            "Analog input filter",
-            "Filter optimization",
-            "Low pass corner frequency",
-            "Low pass rolloff",
-            "High pass corner frequency",
-            "High pass rolloff",
-        }:
-            self.set_analog_filter()
-            changed.add("Range")  # the available ranges depend on the filter optimization
-        if "Input configuration" in changed:
-            self.set_input_configuration(self.input_config)
-        if "Coupling" in changed:
-            self.set_coupling(self.coupling)
-        if "Range" in changed:
-            self.set_range()
-        if "Averaging time (NPLC)" in changed:
-            self.set_nplc(self.nplc)
-        if "Resistance source" in changed:
-            self.set_resistance_source()
-        if "Turn off LED" in changed:
-            self.set_advanced_settings()
-
     def measure(self) -> None:
         """Trigger a new reading; the query returns after settling and the averaging time (NPLC)."""
         if self.mode == "AC":

--- a/src/Logger-LakeShore_M81-VM-10/main.py
+++ b/src/Logger-LakeShore_M81-VM-10/main.py
@@ -173,9 +173,7 @@ class Device(EmptyDevice):
         self.port_string = parameters.get("Port", "")
         self.mode = parameters.get("Mode", "DC")
         self.range = self.voltage_ranges.get(parameters.get("Range", "Auto"), 0.0)
-        self.input_config = self.input_configurations.get(
-            parameters.get("Input configuration", "A-B"), "AB"
-        )
+        self.input_config = self.input_configurations.get(parameters.get("Input configuration", "A-B"), "AB")
         self.coupling = parameters.get("Coupling", "DC")
         self.include_peaks = bool(parameters.get("Include peak values", False))
         # Calculated DC resistance is only available in DC mode
@@ -194,16 +192,12 @@ class Device(EmptyDevice):
             self.lowpass_corner = self.cutoff_frequencies.get(
                 parameters.get("Low pass corner frequency", "None"), "NONE"
             )
-            self.lowpass_rolloff = self.filter_rolloffs.get(
-                parameters.get("Low pass rolloff", "6 dB/oct"), 6
-            )
+            self.lowpass_rolloff = self.filter_rolloffs.get(parameters.get("Low pass rolloff", "6 dB/oct"), 6)
             if self.mode == "AC":
                 self.highpass_corner = self.cutoff_frequencies.get(
                     parameters.get("High pass corner frequency", "None"), "NONE"
                 )
-                self.highpass_rolloff = self.filter_rolloffs.get(
-                    parameters.get("High pass rolloff", "6 dB/oct"), 6
-                )
+                self.highpass_rolloff = self.filter_rolloffs.get(parameters.get("High pass rolloff", "6 dB/oct"), 6)
             else:
                 self.highpass_corner = "NONE"
 
@@ -285,10 +279,7 @@ class Device(EmptyDevice):
         """Verify that the module connected to the selected channel is a VM-10."""
         model = self.port.query(f"SENSe{self.slot}:MODel?")
         if "VM-10" not in model:
-            msg = (
-                f"Device connected on channel M{self.slot} does not match this driver. "
-                f"Found: '{model}'"
-            )
+            msg = f"Device connected on channel M{self.slot} does not match this driver. " f"Found: '{model}'"
             raise ValueError(msg)
 
     def set_mode(self, mode: str) -> None:


### PR DESCRIPTION
Drivers for the VM-10 module of the Lakeshore M81 SSM.
Smaller changes to drivers for CM-10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the LakeShore M81 VM-10 lock-in voltage module, including configurable measurements, filtering, averaging, resistance calculations, sweeps, and status monitoring.
  * Enhanced the VM-10 logger with DC/AC modes, autoranging, manual ranges, coupling, peak measurements, resistance calculations, and LED dark mode.
* **Bug Fixes**
  * Improved measurement settling behavior and corrected time-constant validation feedback.
* **Documentation**
  * Added comprehensive setup, measurement, licensing, and usage documentation for both VM-10 modules.
  * Clarified the current-logging module identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->